### PR TITLE
Simple Guice support

### DIFF
--- a/patches/api/0086-Simple-Guice-support.patch
+++ b/patches/api/0086-Simple-Guice-support.patch
@@ -1,0 +1,201 @@
+From 3c0293edf40dab7500d166fbcfa0839952e1c697 Mon Sep 17 00:00:00 2001
+From: Austin Mayes <austin@avicus.net>
+Date: Sat, 29 Sep 2018 17:22:39 -0500
+Subject: [PATCH] Simple Guice support
+
+
+diff --git a/pom.xml b/pom.xml
+index 8a304559..efafb99c 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -87,6 +87,11 @@
+             <type>jar</type>
+             <scope>compile</scope>
+         </dependency>
++        <dependency>
++            <groupId>network.stratus</groupId>
++            <artifactId>ubique</artifactId>
++            <version>1.0.0-SNAPSHOT</version>
++        </dependency>
+ 
+         <!-- testing -->
+         <dependency>
+diff --git a/src/main/java/org/bukkit/PluginInstanceModule.java b/src/main/java/org/bukkit/PluginInstanceModule.java
+new file mode 100644
+index 00000000..ee56ac8e
+--- /dev/null
++++ b/src/main/java/org/bukkit/PluginInstanceModule.java
+@@ -0,0 +1,22 @@
++package org.bukkit;
++
++import network.stratus.ubique.inject.ProtectedModule;
++import org.bukkit.plugin.Plugin;
++
++/**
++ * Configures a {@link Plugin} instance
++ */
++public class PluginInstanceModule extends ProtectedModule {
++
++  private final Plugin plugin;
++
++  public PluginInstanceModule(Plugin plugin) {
++    this.plugin = plugin;
++  }
++
++  @Override
++  protected void configure() {
++    bind(Plugin.class).toInstance(plugin);
++    plugin.configure(binder());
++  }
++}
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index e7878915..849b322a 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1,5 +1,6 @@
+ package org.bukkit;
+ 
++import com.google.inject.Injector;
+ import java.awt.image.BufferedImage;
+ import java.io.File;
+ import java.io.Serializable;
+@@ -1096,6 +1097,15 @@ public interface Server extends PluginMessageRecipient {
+             player.sendMessage(translatable.translate(player.getLocale()));
+         }
+     }
++
++    /**
++     * Return the global {@link Injector}.
++     *
++     * Note that direct injector use is considered bad form,
++     * and is only provided to assist in migrating legacy code.
++     * Nice code should @Inject its dependencies.
++     */
++    Injector injector();
+     // SportPaper end
+ 
+     public class Spigot
+diff --git a/src/main/java/org/bukkit/ServerInstanceModule.java b/src/main/java/org/bukkit/ServerInstanceModule.java
+new file mode 100644
+index 00000000..172cb239
+--- /dev/null
++++ b/src/main/java/org/bukkit/ServerInstanceModule.java
+@@ -0,0 +1,31 @@
++package org.bukkit;
++
++import java.util.Collection;
++import network.stratus.ubique.inject.KeyedModule;
++import network.stratus.ubique.inject.ProtectedBinder;
++import org.bukkit.plugin.Plugin;
++
++/**
++ * Configures a {@link Server} instance and a collection of {@link Plugin}s.
++ */
++public class ServerInstanceModule extends KeyedModule {
++
++  private final Server server;
++  private final Collection<Plugin> plugins;
++
++  public ServerInstanceModule(Server server, Collection<Plugin> plugins) {
++    super(server);
++    this.server = server;
++    this.plugins = plugins;
++  }
++
++  @Override
++  protected void configure() {
++    bind(Server.class).toInstance(server);
++
++    for(Plugin plugin : plugins) {
++      ProtectedBinder.newProtectedBinder(binder())
++          .install(new PluginInstanceModule(plugin));
++    }
++  }
++}
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 7bdc809c..709848f6 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -1,9 +1,11 @@
+ package org.bukkit.plugin;
+ 
++import com.google.inject.Injector;
+ import java.io.File;
+ import java.io.InputStream;
+ import java.util.logging.Logger;
+ 
++import network.stratus.ubique.inject.ProtectedBinder;
+ import org.bukkit.Server;
+ import org.bukkit.command.TabExecutor;
+ import org.bukkit.configuration.file.FileConfiguration;
+@@ -186,4 +188,28 @@ public interface Plugin extends TabExecutor {
+      * @return name of the plugin
+      */
+     public String getName();
++
++    // SportPaper start
++
++    /**
++     * Return the private {@link Injector} for this plugin.
++     *
++     * Note that direct injector use is considered bad form,
++     * and is only provided to assist in migrating legacy code.
++     * Nice code should @Inject its dependencies.
++     */
++    Injector injector();
++
++    /**
++     * Called during {@link Injector} creation to configure this plugin. This happens
++     * during server startup, before {@link #onLoad()} is called.
++     *
++     * The given {@link ProtectedBinder} belongs to this plugin's private environment,
++     * and the binder returned from {@link ProtectedBinder#publicBinder()} is the global
++     * environment shared by all plugins, and the server itself.
++     *
++     */
++    default void configure(ProtectedBinder binder) {}
++
++    // SportPaper end
+ }
+diff --git a/src/main/java/org/bukkit/plugin/PluginBase.java b/src/main/java/org/bukkit/plugin/PluginBase.java
+index 6031af11..9dadbc04 100644
+--- a/src/main/java/org/bukkit/plugin/PluginBase.java
++++ b/src/main/java/org/bukkit/plugin/PluginBase.java
+@@ -1,5 +1,8 @@
+ package org.bukkit.plugin;
+ 
++import com.google.inject.Inject;
++import com.google.inject.Injector;
++
+ /**
+  * Represents a base {@link Plugin}
+  * <p>
+@@ -7,6 +10,8 @@ package org.bukkit.plugin;
+  * org.bukkit.plugin.java.JavaPlugin}
+  */
+ public abstract class PluginBase implements Plugin {
++    @Inject private Injector injector;
++
+     @Override
+     public final int hashCode() {
+         return getName().hashCode();
+@@ -29,4 +34,16 @@ public abstract class PluginBase implements Plugin {
+     public final String getName() {
+         return getDescription().getName();
+     }
++
++    protected void assertInjected() {
++        if(injector == null) {
++            throw new IllegalStateException("Not available until plugin has been injected");
++        }
++    }
++
++    @Override
++    public Injector injector() {
++        assertInjected();
++        return injector;
++    }
+ }
+-- 
+2.19.0
+

--- a/patches/api/0087-Support-plugins-that-are-just-Guice-modules.patch
+++ b/patches/api/0087-Support-plugins-that-are-just-Guice-modules.patch
@@ -1,0 +1,96 @@
+From 31e6319cd9ff86300a72848ee249bf425cdf92e6 Mon Sep 17 00:00:00 2001
+From: Austin Mayes <austin@avicus.net>
+Date: Tue, 1 Jan 2019 18:39:52 -0600
+Subject: [PATCH] Support plugins that are just Guice modules
+
+
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 12d797f4..e244afac 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -14,7 +14,7 @@ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+-
++import javax.annotation.Nullable;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Server;
+ import org.bukkit.Warning.WarningState;
+@@ -59,7 +59,13 @@ public abstract class JavaPlugin extends PluginBase {
+     private PluginLogger logger = null;
+ 
+     public JavaPlugin() {
+-        final ClassLoader classLoader = this.getClass().getClassLoader();
++        this(null);
++    }
++
++    JavaPlugin(@Nullable ClassLoader classLoader) {
++        if(classLoader == null) {
++            classLoader = getClass().getClassLoader();
++        }
+         if (!(classLoader instanceof PluginClassLoader)) {
+             throw new IllegalStateException("JavaPlugin requires " + PluginClassLoader.class.getName());
+         }
+diff --git a/src/main/java/org/bukkit/plugin/java/ModularPlugin.java b/src/main/java/org/bukkit/plugin/java/ModularPlugin.java
+new file mode 100644
+index 00000000..dae095a9
+--- /dev/null
++++ b/src/main/java/org/bukkit/plugin/java/ModularPlugin.java
+@@ -0,0 +1,18 @@
++package org.bukkit.plugin.java;
++
++import com.google.inject.Module;
++import network.stratus.ubique.inject.ProtectedBinder;
++
++class ModularPlugin extends JavaPlugin {
++
++    private final Module module;
++
++    ModularPlugin(Module module) {
++        super(module.getClass().getClassLoader());
++        this.module = module;
++    }
++
++    public void configure(ProtectedBinder binder) {
++        binder.install(module);
++    }
++}
+\ No newline at end of file
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index b2cbf9e4..f9d079e1 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.plugin.java;
+ 
++import com.google.inject.Module;
+ import java.io.File;
+ import java.net.MalformedURLException;
+ import java.net.URL;
+@@ -67,14 +68,15 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+                 throw new InvalidPluginException("Cannot find main class `" + description.getMain() + "'", ex);
+             }
+ 
+-            Class<? extends JavaPlugin> pluginClass;
+-            try {
+-                pluginClass = jarClass.asSubclass(JavaPlugin.class);
+-            } catch (ClassCastException ex) {
+-                throw new InvalidPluginException("main class `" + description.getMain() + "' does not extend JavaPlugin", ex);
++            if(JavaPlugin.class.isAssignableFrom(jarClass)) {
++                plugin = jarClass.asSubclass(JavaPlugin.class).newInstance();
++            } else if(Module.class.isAssignableFrom(jarClass)) {
++                plugin = new ModularPlugin(jarClass.asSubclass(Module.class).newInstance());
++            } else {
++                throw new InvalidPluginException("main class `" + jarClass.getName() +
++                                                 "' must extend either " + JavaPlugin.class.getName() +
++                                                 " or " + Module.class.getName());
+             }
+-
+-            plugin = pluginClass.newInstance();
+         } catch (IllegalAccessException ex) {
+             throw new InvalidPluginException("No public constructor", ex);
+         } catch (InstantiationException ex) {
+-- 
+2.19.0
+

--- a/patches/api/0088-Add-command-unregistration-API.patch
+++ b/patches/api/0088-Add-command-unregistration-API.patch
@@ -1,0 +1,79 @@
+From 68045b517df5e77905acc27ab0f492fc8844f17c Mon Sep 17 00:00:00 2001
+From: Austin Mayes <austin@avicus.net>
+Date: Fri, 4 Jan 2019 18:05:36 -0600
+Subject: [PATCH] Add command unregistration API
+
+
+diff --git a/src/main/java/org/bukkit/command/CommandMap.java b/src/main/java/org/bukkit/command/CommandMap.java
+index e7e20d89..168d6a90 100644
+--- a/src/main/java/org/bukkit/command/CommandMap.java
++++ b/src/main/java/org/bukkit/command/CommandMap.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.command;
+ 
+ import java.util.List;
++import java.util.function.Predicate;
+ 
+ public interface CommandMap {
+ 
+@@ -65,6 +66,21 @@ public interface CommandMap {
+      */
+     public boolean register(String fallbackPrefix, Command command);
+ 
++    /**
++     * Unregister a specific command.
++     *
++     * @param command to unregister
++     * @return if the command was actually registered in the first place
++     */
++    boolean unregister(Command command);
++
++    /**
++     * Unregister all commands which match the supplied filter.
++     *
++     * @param filter to check commands against for un-registration
++     */
++    void unregisterAll(Predicate<? super Command> filter);
++
+     /**
+      * Looks for the requested command and executes it if found.
+      *
+diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+index 10d07114..af311aaa 100644
+--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
++++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+@@ -9,6 +9,7 @@ import java.util.HashMap;
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Map;
++import java.util.function.Predicate;
+ import java.util.regex.Pattern;
+ 
+ import org.apache.commons.lang.Validate;
+@@ -124,6 +125,23 @@ public class SimpleCommandMap implements CommandMap {
+         return registered;
+     }
+ 
++    @Override
++    public boolean unregister(Command command) {
++       command.unregister(this);
++       return knownCommands.values().removeIf(command::equals);
++    }
++
++    @Override
++    public void unregisterAll(Predicate<? super Command> filter) {
++        knownCommands.values().removeIf(command -> {
++            if(filter.test(command)) {
++                command.unregister(this);
++                return true;
++            }
++            return false;
++        });
++    }
++
+     /**
+      * {@inheritDoc}
+      */
+-- 
+2.19.0
+

--- a/patches/api/0089-Unregister-plugin-commands-on-disable.patch
+++ b/patches/api/0089-Unregister-plugin-commands-on-disable.patch
@@ -1,0 +1,36 @@
+From 859f6b0b5b8d4b9b14afd57087bc391bb2f61356 Mon Sep 17 00:00:00 2001
+From: Austin Mayes <austin@avicus.net>
+Date: Fri, 4 Jan 2019 18:05:48 -0600
+Subject: [PATCH] Unregister plugin commands on disable
+
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 3447aae4..5e58e8f8 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -22,6 +22,7 @@ import org.apache.commons.lang.Validate;
+ import org.bukkit.Server;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.PluginCommandYamlParser;
++import org.bukkit.command.PluginIdentifiableCommand;
+ import org.bukkit.command.SimpleCommandMap;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.EventCallback;
+@@ -452,6 +453,14 @@ public final class SimplePluginManager implements PluginManager {
+                         + plugin.getDescription().getFullName() + " (Is it up to date?)", ex, plugin); // Paper
+             }
+ 
++            try {
++                server.getCommandMap().unregisterAll(command -> command instanceof PluginIdentifiableCommand &&
++                                                                plugin == ((PluginIdentifiableCommand) command).getPlugin());
++            } catch (Throwable ex) {
++                server.getLogger().log(Level.SEVERE, "Error occurred (in the plugin loader) while unregistering commands for " +
++                                                     plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
++            }
++
+             try {
+                 server.getMessenger().unregisterIncomingPluginChannel(plugin);
+                 server.getMessenger().unregisterOutgoingPluginChannel(plugin);
+-- 
+2.19.0
+

--- a/patches/server/0166-Simple-Guice-support.patch
+++ b/patches/server/0166-Simple-Guice-support.patch
@@ -1,0 +1,110 @@
+From 8d489414e1989a32ce46037d96e077a367c173ef Mon Sep 17 00:00:00 2001
+From: Austin Mayes <austin@avicus.net>
+Date: Sat, 29 Sep 2018 17:22:49 -0500
+Subject: [PATCH] Simple Guice support
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index dba05d97..340f573f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1,5 +1,8 @@
+ package org.bukkit.craftbukkit;
+ 
++import com.google.inject.Guice;
++import com.google.inject.Injector;
++import com.google.inject.Stage;
+ import java.awt.image.BufferedImage;
+ import java.io.File;
+ import java.io.FileInputStream;
+@@ -34,6 +37,7 @@ import org.bukkit.GameMode;
+ import org.bukkit.Location;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.Server;
++import org.bukkit.ServerInstanceModule;
+ import org.bukkit.UnsafeValues;
+ import org.bukkit.Warning.WarningState;
+ import org.bukkit.World;
+@@ -169,6 +173,8 @@ public final class CraftServer implements Server {
+     private final List<CraftPlayer> playerView;
+ 
+     private @Nullable Instant emptySince;
++    protected @Nullable Injector injector;
++
+ 
+     private final class BooleanWrapper {
+         private boolean value = true;
+@@ -243,6 +249,17 @@ public final class CraftServer implements Server {
+ 
+         if (pluginFolder.exists()) {
+             Plugin[] plugins = pluginManager.loadPlugins(pluginFolder);
++
++            final Stage stage = console.options.valueOf(Main.GUICE_STAGE_OPTION);
++            logger.info("Creating injector in stage " + stage);
++
++            try {
++                injector = Guice.createInjector(stage, new ServerInstanceModule(this, Arrays.asList(plugins)));
++            } catch(RuntimeException ex) {
++                logger.log(Level.SEVERE, "Injector creation failed, server will shut down", ex);
++                throw ex;
++            }
++
+             for (Plugin plugin : plugins) {
+                 try {
+                     String message = String.format("Loading %s", plugin.getDescription().getFullName());
+@@ -1811,6 +1828,16 @@ public final class CraftServer implements Server {
+         }
+     };
+ 
++    // SportPaper start
++    @Override
++    public Injector injector() {
++        if(injector == null) {
++            throw new IllegalStateException("Injector has not been created yet");
++        }
++        return injector;
++    }
++    // Sportpaper end
++
+     public Spigot spigot()
+     {
+         return spigot;
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index d1ce7a86..4d8492e0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.craftbukkit;
+ 
++import com.google.inject.Stage;
+ import java.io.File;
+ import java.io.IOException;
+ import java.text.SimpleDateFormat;
+@@ -9,10 +10,13 @@ import java.util.logging.Level;
+ import java.util.logging.Logger;
+ import joptsimple.OptionParser;
+ import joptsimple.OptionSet;
++import joptsimple.OptionSpec;
+ import net.minecraft.server.MinecraftServer;
+ import org.fusesource.jansi.AnsiConsole;
+ 
+ public class Main {
++    public static OptionSpec<Stage> GUICE_STAGE_OPTION;
++
+     public static boolean useJline = true;
+     public static boolean useConsole = true;
+ 
+@@ -155,6 +159,10 @@ public class Main {
+                         .ofType(File.class)
+                         .defaultsTo(new File("sportpaper.yml"))
+                         .describedAs("Yml file");
++                GUICE_STAGE_OPTION = acceptsAll(asList("stage"), "Guice run stage (development/production)")
++                    .withRequiredArg()
++                    .ofType(com.google.inject.Stage.class)
++                    .defaultsTo(com.google.inject.Stage.PRODUCTION);
+                 // SportPaper end
+ 
+                 // Paper start
+-- 
+2.19.0
+


### PR DESCRIPTION
Adds bare-bones guice plugin support based on the larger patch from SportBukkit. 

* Each plugin is it's own `ProtectedModule` where the `publicBinder()` is the global server binder
* `Server` is globally provided
* `Plugin` is provided inside each module and bound to the current containing plugin instance

__NOTE:__ This will fail to build until @Electroid sets up builds for [Ubique](https://github.com/StratusNetwork/Ubique)