### PR TITLE
Add cave frequency API

### DIFF
--- a/patches/api/0092-Add-cave-frequency-API.patch
+++ b/patches/api/0092-Add-cave-frequency-API.patch
@@ -1,0 +1,32 @@
+From 3c13ca031cbe5954f69311222803183d4c3b7c83 Mon Sep 17 00:00:00 2001
+From: Rafi Baum <rafi@ukbaums.com>
+Date: Sun, 21 Apr 2019 22:52:42 -0400
+Subject: [PATCH] Add cave frequency API
+
+
+diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+index 51370245..095d2fea 100644
+--- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
++++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+@@ -305,6 +305,18 @@ public abstract class ChunkGenerator {
+         return null;
+     }
+ 
++    /**
++     * Gets the frequency of cave spawns in the world.
++     * <p>
++     * This is represented as a number from 1 to infinity and is the inverse of the chance that
++     * a cave will spawn in any given chunk. The vanilla default is 7.
++     *
++     * @return the inverse of the chance a cave will spawn in any given chunk
++     */
++    public int getCaveFrequency() {
++        return 7;
++    }
++
+     /**
+      * Data for a Chunk.
+      */
+-- 
+2.17.1
+

--- a/patches/server/0174-Add-cave-frequency-API.patch
+++ b/patches/server/0174-Add-cave-frequency-API.patch
@@ -1,0 +1,22 @@
+From 8bbb82311f466f2442ab8e5af4184fe2c000c1ef Mon Sep 17 00:00:00 2001
+From: Rafi Baum <rafi@ukbaums.com>
+Date: Sun, 21 Apr 2019 22:53:07 -0400
+Subject: [PATCH] Add cave frequency API
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldGenCaves.java b/src/main/java/net/minecraft/server/WorldGenCaves.java
+index 2cdd0237..68f413a6 100644
+--- a/src/main/java/net/minecraft/server/WorldGenCaves.java
++++ b/src/main/java/net/minecraft/server/WorldGenCaves.java
+@@ -184,7 +184,7 @@ public class WorldGenCaves extends WorldGenBase {
+     protected void a(World world, int i, int j, int k, int l, ChunkSnapshot chunksnapshot) {
+         int i1 = this.b.nextInt(this.b.nextInt(this.b.nextInt(15) + 1) + 1);
+ 
+-        if (this.b.nextInt(7) != 0) {
++        if (this.b.nextInt(world.generator.getCaveFrequency()) != 0) { // SportBukkit - Pull cave frequency from chunk generator
+             i1 = 0;
+         }
+ 
+-- 
+2.17.1
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -50,6 +50,7 @@ import StatisticList
 import PacketPlayOutSpawnEntity
 import ItemGoldenApple
 import ItemPotion
+import WorldGenCaves
 
 cd "$basedir/base/Paper/PaperSpigot-Server/"
 rm -rf nms-patches applyPatches.sh makePatches.sh >/dev/null 2>&1


### PR DESCRIPTION
Bukkit has next to no interface for modifying how world generation behaves outside of what vanilla Minecraft already offers you, so there was no obvious place for this API to go. In the end, I decided to add a function to the chunk generator API for the following reasons:
1. Any changes to cave generation frequency would only work with a modified server/appropriate plugin. A lot of the vanilla settings for modifying world generation work no matter where a world is installed, but obviously this mechanism doesn't really work the same way so it doesn't make sense to place this API alongside other vanilla generation settings which are more permanent.
2. It's relatively easy to access the chunk generator for a world from within NMS world generation methods.
3. This modification simulates the effects of having a custom chunk generator with modified cave frequencies.

There are some drawbacks to placing the API here. Chiefly, it adds new functionality to the ChunkGenerator class that would previously be considered out of its scope. The ChunkGenerator has a kind of "black box" design which is meant to permit the overriding of entire sections of the world generation process, not tweaking small parts of it. A more organised solution would be to create a new world generation customisation API which would allow the tweaking of NMS variables and add that to the world creation API. If we end up doing more world generation customisation, I think we should go down this path. Right now however, I don't really believe that it's worth it.