### PR TITLE
Add Velocity proxy support

### DIFF
--- a/patches/server/0183-Add-support-for-custom-login-packets-from-1.13-clien.patch
+++ b/patches/server/0183-Add-support-for-custom-login-packets-from-1.13-clien.patch
@@ -1,0 +1,282 @@
+From c29690732399472b1c3b352f042d7e9b4a601ce3 Mon Sep 17 00:00:00 2001
+From: Ashcon Partovi <ashcon@partovi.net>
+Date: Sat, 4 May 2019 13:34:34 -0700
+Subject: [PATCH] Add support for custom login packets from 1.13+ clients
+
+
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 1160f45eb..98c7734c4 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -253,6 +253,13 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+         }
+     }
+ 
++    // SportPaper start - handle custom login payloads for 1.13+ clients
++    @Override
++    public void a(PacketLoginInCustomPayload packetloginincustompayload) {
++        this.disconnect("Unexpected custom data from client");
++    }
++    // SportPaper end
++
+     // Paper start - Delay async prelogin until plugins are ready
+     private static volatile Object blockingLogins = new Object();
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+index e2eb30546..297692711 100644
+--- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
++++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+@@ -69,22 +69,27 @@ public class PacketDataSerializer extends ByteBuf {
+         this.writeLong(blockposition.asLong());
+     }
+ 
+-    public IChatBaseComponent d() throws IOException {
++    public IChatBaseComponent readChat() { return this.d(); } // SportPaper - OBFHELPER
++    public IChatBaseComponent d() {
+         return IChatBaseComponent.ChatSerializer.a(this.c(32767));
+     }
+ 
++    public void writeChat(IChatBaseComponent ichatbasecomponent) throws IOException { this.a(ichatbasecomponent); } // SportPaper - OBFHELPER
+     public void a(IChatBaseComponent ichatbasecomponent) throws IOException {
+         this.a(IChatBaseComponent.ChatSerializer.a(ichatbasecomponent));
+     }
+ 
++    public <T extends Enum<T>> T readEnum(Class<T> oclass) { return this.a(oclass); } // SportPaper - OBFHELPER
+     public <T extends Enum<T>> T a(Class<T> oclass) {
+         return ((T[]) oclass.getEnumConstants())[this.e()]; // CraftBukkit - fix decompile error
+     }
+ 
++    public void writeEnum(Enum<?> oenum) { this.a(oenum); } // SportPaper - OBFHELPER
+     public void a(Enum<?> oenum) {
+         this.b(oenum.ordinal());
+     }
+ 
++    public int readVarInt() { return this.e(); } // SportPaper - OBFHELPER
+     public int e() {
+         int i = 0;
+         int j = 0;
+@@ -102,6 +107,7 @@ public class PacketDataSerializer extends ByteBuf {
+         return i;
+     }
+ 
++    public long readVarLong() { return this.f(); } // SportPaper - OBFHELPER
+     public long f() {
+         long i = 0L;
+         int j = 0;
+@@ -119,15 +125,18 @@ public class PacketDataSerializer extends ByteBuf {
+         return i;
+     }
+ 
++    public void writeUUID(UUID uuid) { this.a(uuid); } // SportPaper - OBFHELPER
+     public void a(UUID uuid) {
+         this.writeLong(uuid.getMostSignificantBits());
+         this.writeLong(uuid.getLeastSignificantBits());
+     }
+ 
++    public UUID readUUID() { return this.g(); } // SportPaper - OBFHELPER
+     public UUID g() {
+         return new UUID(this.readLong(), this.readLong());
+     }
+ 
++    public void writeVarInt(int i) { this.b(i); } // SportPaper - OBFHELPER
+     public void b(int i) {
+         while ((i & -128) != 0) {
+             this.writeByte(i & 127 | 128);
+@@ -137,6 +146,7 @@ public class PacketDataSerializer extends ByteBuf {
+         this.writeByte(i);
+     }
+ 
++    public void writeVarLong(long i) { this.b(i); } // SportPaper - OBFHELPER
+     public void b(long i) {
+         while ((i & -128L) != 0L) {
+             this.writeByte((int) (i & 127L) | 128);
+@@ -146,6 +156,7 @@ public class PacketDataSerializer extends ByteBuf {
+         this.writeByte((int) i);
+     }
+ 
++    public void writeNBT(NBTTagCompound nbttagcompound) { this.a(nbttagcompound); } // SportPaper - OBFHELPER
+     public void a(NBTTagCompound nbttagcompound) {
+         if (nbttagcompound == null) {
+             this.writeByte(0);
+@@ -159,6 +170,7 @@ public class PacketDataSerializer extends ByteBuf {
+ 
+     }
+ 
++    public NBTTagCompound readNBT() throws IOException { return this.h(); } // SportPaper - OBFHELPER
+     public NBTTagCompound h() throws IOException {
+         int i = this.readerIndex();
+         byte b0 = this.readByte();
+@@ -171,6 +183,7 @@ public class PacketDataSerializer extends ByteBuf {
+         }
+     }
+ 
++    public void writeItemStack(ItemStack itemstack) { this.a(itemstack); } // SportPaper - OBFHELPER
+     public void a(ItemStack itemstack) {
+         if (itemstack == null || itemstack.getItem() == null) { // CraftBukkit - NPE fix itemstack.getItem()
+             this.writeShort(-1);
+@@ -193,6 +206,7 @@ public class PacketDataSerializer extends ByteBuf {
+ 
+     }
+ 
++    public ItemStack readItemStack() throws IOException { return this.i(); } // SportPaper - OBFHELPER
+     public ItemStack i() throws IOException {
+         ItemStack itemstack = null;
+         short short0 = this.readShort();
+@@ -213,6 +227,7 @@ public class PacketDataSerializer extends ByteBuf {
+         return itemstack;
+     }
+ 
++    public String readUTF(int maxLength) { return this.c(maxLength); } // SportPaper - OBFHELPER
+     public String c(int i) {
+         int j = this.e();
+ 
+@@ -231,6 +246,7 @@ public class PacketDataSerializer extends ByteBuf {
+         }
+     }
+ 
++    public PacketDataSerializer writeUTF(String s) { return this.a(s); } // SportPaper - OBFHELPER
+     public PacketDataSerializer a(String s) {
+         byte[] abyte = s.getBytes(Charsets.UTF_8);
+ 
+@@ -243,6 +259,26 @@ public class PacketDataSerializer extends ByteBuf {
+         }
+     }
+ 
++    // SportPaper - add serialization methods from 1.13+
++    public MinecraftKey readKey() {
++        return new MinecraftKey(this.readUTF(32767));
++    }
++
++    public PacketDataSerializer writeKey(MinecraftKey minecraftkey) {
++        this.writeUTF(minecraftkey.toString());
++        return this;
++    }
++
++    public java.util.Date m() {
++        return new java.util.Date(this.readLong());
++    }
++
++    public PacketDataSerializer a(java.util.Date date) {
++        this.writeLong(date.getTime());
++        return this;
++    }
++    // SportPaper - end
++
+     public int capacity() {
+         return this.a.capacity();
+     }
+diff --git a/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java b/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
+new file mode 100644
+index 000000000..fcdb388ad
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
+@@ -0,0 +1,42 @@
++package net.minecraft.server;
++
++import java.io.IOException;
++
++public class PacketLoginInCustomPayload implements Packet<PacketLoginInListener> {
++
++    private int a;
++    private PacketDataSerializer b;
++
++    public PacketLoginInCustomPayload() {}
++
++    public void a(PacketDataSerializer packetdataserializer) throws IOException {
++        this.a = packetdataserializer.readVarInt();
++        if (packetdataserializer.readBoolean()) {
++            int i = packetdataserializer.readableBytes();
++
++            if (i < 0 || i > 1048576) {
++                throw new IOException("Payload may not be larger than 1048576 bytes");
++            }
++
++            this.b = new PacketDataSerializer(packetdataserializer.readBytes(i));
++        } else {
++            this.b = null;
++        }
++
++    }
++
++    public void b(PacketDataSerializer packetdataserializer) throws IOException {
++        packetdataserializer.writeVarInt(this.a);
++        if (this.b != null) {
++            packetdataserializer.writeBoolean(true);
++            packetdataserializer.writeBytes(this.b.copy());
++        } else {
++            packetdataserializer.writeBoolean(false);
++        }
++
++    }
++
++    public void a(PacketLoginInListener packetlogininlistener) {
++        packetlogininlistener.a(this);
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/PacketLoginInListener.java b/src/main/java/net/minecraft/server/PacketLoginInListener.java
+index 96689a07f..c4eaa7cf4 100644
+--- a/src/main/java/net/minecraft/server/PacketLoginInListener.java
++++ b/src/main/java/net/minecraft/server/PacketLoginInListener.java
+@@ -5,4 +5,7 @@ public interface PacketLoginInListener extends PacketListener {
+     void a(PacketLoginInStart packetlogininstart);
+ 
+     void a(PacketLoginInEncryptionBegin packetlogininencryptionbegin);
++
++    // SportPaper - add custom payload packet from 1.13+
++    void a(PacketLoginInCustomPayload packetloginincustompayload);
+ }
+diff --git a/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java b/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
+new file mode 100644
+index 000000000..611fd8bcc
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
+@@ -0,0 +1,34 @@
++package net.minecraft.server;
++
++import java.io.IOException;
++
++public class PacketLoginOutCustomPayload implements Packet<PacketLoginOutListener> {
++
++    private int a;
++    private MinecraftKey b;
++    private PacketDataSerializer c;
++
++    public PacketLoginOutCustomPayload() {}
++
++    public void a(PacketDataSerializer packetdataserializer) throws IOException {
++        this.a = packetdataserializer.readVarInt();
++        this.b = packetdataserializer.readKey();
++        int i = packetdataserializer.readableBytes();
++
++        if (i >= 0 && i <= 1048576) {
++            this.c = new PacketDataSerializer(packetdataserializer.readBytes(i));
++        } else {
++            throw new IOException("Payload may not be larger than 1048576 bytes");
++        }
++    }
++
++    public void b(PacketDataSerializer packetdataserializer) throws IOException {
++        packetdataserializer.writeVarInt(this.a);
++        packetdataserializer.writeKey(this.b);
++        packetdataserializer.writeBytes(this.c.copy());
++    }
++
++    public void a(PacketLoginOutListener packetloginoutlistener) {
++        packetloginoutlistener.a(this);
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/PacketLoginOutListener.java b/src/main/java/net/minecraft/server/PacketLoginOutListener.java
+index 2067b0564..a6e625e32 100644
+--- a/src/main/java/net/minecraft/server/PacketLoginOutListener.java
++++ b/src/main/java/net/minecraft/server/PacketLoginOutListener.java
+@@ -9,4 +9,7 @@ public interface PacketLoginOutListener extends PacketListener {
+     void a(PacketLoginOutDisconnect packetloginoutdisconnect);
+ 
+     void a(PacketLoginOutSetCompression packetloginoutsetcompression);
++
++    // SportPaper - add custom payload packet from 1.13+
++    void a(PacketLoginOutCustomPayload packetloginoutcustompayload);
+ }
+-- 
+2.20.1
+

--- a/patches/server/0184-Add-Velocity-proxy-support.patch
+++ b/patches/server/0184-Add-Velocity-proxy-support.patch
@@ -1,0 +1,269 @@
+From de5bd8a87dbecae8dff6a4ebbfd69c874fe05623 Mon Sep 17 00:00:00 2001
+From: Ashcon Partovi <ashcon@partovi.net>
+Date: Sat, 4 May 2019 14:17:14 -0700
+Subject: [PATCH] Add Velocity proxy support
+
+
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 98c7734c4..e7abeb692 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -40,6 +40,7 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+     private SecretKey loginKey;
+     private EntityPlayer l;
+     public String hostname = ""; // CraftBukkit - add field
++    private int velocityLoginMessageId = -1; // SportPaper - Velocity support
+ 
+     public LoginListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
+         this.g = LoginListener.EnumProtocolState.HELLO;
+@@ -179,6 +180,14 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+             this.g = LoginListener.EnumProtocolState.KEY;
+             this.networkManager.handle(new PacketLoginOutEncryptionBegin(this.j, this.server.Q().getPublic(), this.e));
+         } else {
++            // SportPaper start - Velocity support
++            if (org.github.paperspigot.PaperSpigotConfig.velocitySupport) {
++                this.velocityLoginMessageId = java.util.concurrent.ThreadLocalRandom.current().nextInt();
++                PacketLoginOutCustomPayload packet = new PacketLoginOutCustomPayload(this.velocityLoginMessageId, org.github.paperspigot.VelocityProxy.PLAYER_INFO_CHANNEL, new PacketDataSerializer(io.netty.buffer.Unpooled.EMPTY_BUFFER));
++                this.networkManager.handle(packet);
++                return;
++            }
++            // SportPaper end
+             // Spigot start
+             initUUID();
+             new Thread(new Runnable() {
+@@ -256,6 +265,31 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+     // SportPaper start - handle custom login payloads for 1.13+ clients
+     @Override
+     public void a(PacketLoginInCustomPayload packetloginincustompayload) {
++        // SportPaper start - Velocity support
++        if (org.github.paperspigot.PaperSpigotConfig.velocitySupport && packetloginincustompayload.getId() == this.velocityLoginMessageId) {
++            PacketDataSerializer buf = packetloginincustompayload.getBuf();
++            if (buf == null) {
++                this.disconnect("This server requires you to connect with Velocity.");
++                return;
++            }
++            if (!org.github.paperspigot.VelocityProxy.checkIntegrity(buf)) {
++                this.disconnect("Unable to verify player details from Velocity.");
++                return;
++            }
++            this.networkManager.setSpoofedRemoteAddress(new java.net.InetSocketAddress(org.github.paperspigot.VelocityProxy.readAddress(buf), ((java.net.InetSocketAddress) this.networkManager.getSocketAddress()).getPort()));
++            this.setGameProfile(org.github.paperspigot.VelocityProxy.createProfile(buf));
++            // Proceed with login
++            authenticatorPool.execute(() -> {
++                try {
++                    new LoginHandler().fireEvents();
++                } catch (Exception ex) {
++                    this.disconnect("Failed to verify username!");
++                    server.server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + i.getName(), ex);
++                }
++            });
++            return;
++        }
++        // SportPaper end
+         this.disconnect("Unexpected custom data from client");
+     }
+     // SportPaper end
+@@ -295,6 +329,12 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+ 
+         public void fireEvents() throws Exception {
+                             LoginListener.checkStartupAndBlock(); // Paper - Delay async login events until plugins are ready
++                            // SportPaper start - Velocity support
++                            if (LoginListener.this.velocityLoginMessageId == -1 && org.github.paperspigot.PaperSpigotConfig.velocitySupport) {
++                                disconnect("This server requires you to connect with Velocity.");
++                                return;
++                            }
++                            // SportPaper end
+                             String playerName = i.getName();
+                             java.net.InetAddress address = ((java.net.InetSocketAddress) networkManager.getSocketAddress()).getAddress();
+                             java.util.UUID uniqueId = i.getId();
+@@ -334,6 +374,7 @@ public class LoginListener implements PacketLoginInListener, IUpdatePlayerListBo
+     }
+     // Spigot end
+ 
++    protected GameProfile setGameProfile(GameProfile gameprofile) { return this.a(gameprofile); } // SportPaper - OBFHELPER
+     protected GameProfile a(GameProfile gameprofile) {
+         UUID uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + gameprofile.getName()).getBytes(Charsets.UTF_8));
+ 
+diff --git a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
+index 40291094e..ed07fcd2c 100644
+--- a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
++++ b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
+@@ -66,7 +66,7 @@ public class NameReferencingFileConverter {
+             }
+         }), String.class);
+ 
+-        if (minecraftserver.getOnlineMode() || org.spigotmc.SpigotConfig.bungee) { // Spigot: bungee = online mode, for now.
++        if (minecraftserver.getOnlineMode() || org.spigotmc.SpigotConfig.bungee || org.github.paperspigot.PaperSpigotConfig.velocityOnlineMode) { // SportPaper - Velocity support
+             minecraftserver.getGameProfileRepository().findProfilesByNames(astring, Agent.MINECRAFT, profilelookupcallback);
+         } else {
+             String[] astring1 = astring;
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index 9e35715a3..cb1078b37 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -65,7 +65,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+     private final ReentrantReadWriteLock j = new ReentrantReadWriteLock();
+     public Channel channel;
+     // Spigot Start // PAIL
+-    public SocketAddress l;
++    public SocketAddress l; public void setSpoofedRemoteAddress(SocketAddress address) { this.l = address; } // SportPaper - OBFHELPER
+     public java.util.UUID spoofedUUID;
+     public com.mojang.authlib.properties.Property[] spoofedProfile;
+     public boolean preparing = true;
+diff --git a/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java b/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
+index fcdb388ad..c53fdcaa6 100644
+--- a/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
++++ b/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
+@@ -4,8 +4,8 @@ import java.io.IOException;
+ 
+ public class PacketLoginInCustomPayload implements Packet<PacketLoginInListener> {
+ 
+-    private int a;
+-    private PacketDataSerializer b;
++    private int a; public int getId() { return this.a; } // SportPaper - OBFHELPER
++    private PacketDataSerializer b; public PacketDataSerializer getBuf() { return this.b; } // SportPaper - OBFHELPER
+ 
+     public PacketLoginInCustomPayload() {}
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java b/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
+index 611fd8bcc..eccb4bb1f 100644
+--- a/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
++++ b/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
+@@ -10,6 +10,14 @@ public class PacketLoginOutCustomPayload implements Packet<PacketLoginOutListene
+ 
+     public PacketLoginOutCustomPayload() {}
+ 
++    // SportPaper start
++    public PacketLoginOutCustomPayload(int id, MinecraftKey channel, PacketDataSerializer buf) {
++        this.a = id;
++        this.b = channel;
++        this.c = buf;
++    }
++    // SportPaper end
++
+     public void a(PacketDataSerializer packetdataserializer) throws IOException {
+         this.a = packetdataserializer.readVarInt();
+         this.b = packetdataserializer.readKey();
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 613582cc4..5b3840a7b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -546,7 +546,7 @@ public final class CraftServer implements Server {
+     @Override
+     public long getConnectionThrottle() {
+         // Spigot Start - Automatically set connection throttle for bungee configurations
+-        if (org.spigotmc.SpigotConfig.bungee) {
++        if (org.spigotmc.SpigotConfig.bungee || org.github.paperspigot.PaperSpigotConfig.velocitySupport) { // SportPaper - Velocity support
+             return -1;
+         } else {
+             return BukkitConfig.connectionThrottle;
+@@ -1224,7 +1224,7 @@ public final class CraftServer implements Server {
+             // Spigot Start
+             GameProfile profile = null;
+             // Only fetch an online UUID in online mode
+-            if ( MinecraftServer.getServer().getOnlineMode() || org.spigotmc.SpigotConfig.bungee )
++            if ( MinecraftServer.getServer().getOnlineMode() || org.spigotmc.SpigotConfig.bungee || org.github.paperspigot.PaperSpigotConfig.velocityOnlineMode ) // SportPaper - Velocity support
+             {
+                 profile = MinecraftServer.getServer().getUserCache().getProfile( name );
+             }
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index 9360eac7f..dc59c674d 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -200,4 +200,20 @@ public class PaperSpigotConfig
+     private static void firePhysicsEventForRedstone() {
+         firePhysicsEventForRedstone = getBoolean("fire-physics-event-for-redstone", firePhysicsEventForRedstone);
+     }
++
++    public static boolean velocitySupport;
++    public static boolean velocityOnlineMode;
++    public static byte[] velocitySecretKey;
++    private static void velocitySupport() {
++        velocitySupport = getBoolean("settings.velocity-support.enabled", false);
++        velocityOnlineMode = getBoolean("settings.velocity-support.online-mode", false);
++        if (!velocitySupport) {
++            velocityOnlineMode = false;
++        }
++        String secret = getString("settings.velocity-support.secret", "");
++        if (velocitySupport && secret.isEmpty()) {
++            Bukkit.getLogger().warning("Velocity support is enabled, but no secret key was specified. A secret key is required!");
++        }
++        velocitySecretKey = secret.getBytes(java.nio.charset.StandardCharsets.UTF_8);
++    }
+ }
+diff --git a/src/main/java/org/github/paperspigot/VelocityProxy.java b/src/main/java/org/github/paperspigot/VelocityProxy.java
+new file mode 100644
+index 000000000..cdf1b7984
+--- /dev/null
++++ b/src/main/java/org/github/paperspigot/VelocityProxy.java
+@@ -0,0 +1,66 @@
++package org.github.paperspigot;
++
++import com.google.common.net.InetAddresses;
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.properties.Property;
++import net.minecraft.server.MinecraftKey;
++import net.minecraft.server.PacketDataSerializer;
++
++import java.net.InetAddress;
++import java.security.InvalidKeyException;
++import java.security.MessageDigest;
++import java.security.NoSuchAlgorithmException;
++
++import javax.crypto.Mac;
++import javax.crypto.spec.SecretKeySpec;
++
++public class VelocityProxy {
++    private static final int SUPPORTED_FORWARDING_VERSION = 1;
++    public static final MinecraftKey PLAYER_INFO_CHANNEL = new MinecraftKey("velocity:player_info");
++
++    public static boolean checkIntegrity(final PacketDataSerializer buf) {
++        final byte[] signature = new byte[32];
++        buf.readBytes(signature);
++
++        final byte[] data = new byte[buf.readableBytes()];
++        buf.getBytes(buf.readerIndex(), data);
++
++        try {
++            final Mac mac = Mac.getInstance("HmacSHA256");
++            mac.init(new SecretKeySpec(PaperSpigotConfig.velocitySecretKey, "HmacSHA256"));
++            final byte[] mySignature = mac.doFinal(data);
++            if (!MessageDigest.isEqual(signature, mySignature)) {
++                return false;
++            }
++        } catch (final InvalidKeyException | NoSuchAlgorithmException e) {
++            throw new AssertionError(e);
++        }
++
++        int version = buf.readVarInt();
++        if (version != SUPPORTED_FORWARDING_VERSION) {
++            throw new IllegalStateException("Unsupported forwarding version " + version + ", wanted " + SUPPORTED_FORWARDING_VERSION);
++        }
++
++        return true;
++    }
++
++    public static InetAddress readAddress(final PacketDataSerializer buf) {
++        return InetAddresses.forString(buf.readUTF(Short.MAX_VALUE));
++    }
++
++    public static GameProfile createProfile(final PacketDataSerializer buf) {
++        final GameProfile profile = new GameProfile(buf.readUUID(), buf.readUTF(16));
++        readProperties(buf, profile);
++        return profile;
++    }
++
++    private static void readProperties(final PacketDataSerializer buf, final GameProfile profile) {
++        final int properties = buf.readVarInt();
++        for (int i1 = 0; i1 < properties; i1++) {
++            final String name = buf.readUTF(Short.MAX_VALUE);
++            final String value = buf.readUTF(Short.MAX_VALUE);
++            final String signature = buf.readBoolean() ? buf.readUTF(Short.MAX_VALUE) : null;
++            profile.getProperties().put(name, new Property(name, value, signature));
++        }
++    }
++}
+\ No newline at end of file
+-- 
+2.20.1
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -40,6 +40,8 @@ import ChunkCache
 import ChunkCoordIntPair
 import EntityTypes
 import ItemFireworks
+import PacketLoginOutListener
+import PacketLoginInListener
 import PacketPlayInUseEntity
 import PacketPlayOutEntityMetadata
 import PacketPlayOutPlayerInfo


### PR DESCRIPTION
Adds support for https://github.com/VelocityPowered/Velocity. Initial testing shows, although, Velocity will required a patch because it does not know SportPaper can support the 1.13 packets.