### PR TITLE
Fix NamedEntitySpawn not initializing data watcher

### DIFF
--- a/patches/server/0183-Fix-NamedEntitySpawn-not-initializing-data-watcher.patch
+++ b/patches/server/0183-Fix-NamedEntitySpawn-not-initializing-data-watcher.patch
@@ -1,0 +1,33 @@
+From ba3e486c1422ef23affb15fa17d16536b65f805a Mon Sep 17 00:00:00 2001
+From: David Rodriguez <15853933+limbo56@users.noreply.github.com>
+Date: Sun, 13 Oct 2019 19:21:28 -0400
+Subject: [PATCH] Fix NamedEntitySpawn not initializing data watcher
+
+
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java b/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
+index 1f2e8f5c..67fc8b4f 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutNamedEntitySpawn.java
+@@ -18,7 +18,7 @@ public class PacketPlayOutNamedEntitySpawn implements Packet<PacketListenerPlayO
+     private List<DataWatcher.WatchableObject> j;
+ 
+     // SportPaper start - add constructor
+-    public PacketPlayOutNamedEntitySpawn(int id, UUID uuid, double xPos, double yPos, double zPos, byte yaw, byte pitch, ItemStack heldItem, List<DataWatcher.WatchableObject> metadata) {
++    public PacketPlayOutNamedEntitySpawn(int id, UUID uuid, double xPos, double yPos, double zPos, byte yaw, byte pitch, ItemStack heldItem, DataWatcher dataWatcher) {
+         this.a = id;
+         this.b = uuid;
+         this.c = MathHelper.floor(xPos * 32.0D);
+@@ -26,8 +26,9 @@ public class PacketPlayOutNamedEntitySpawn implements Packet<PacketListenerPlayO
+         this.e = MathHelper.floor(zPos * 32.0D);
+         this.f = (byte) ((int) (yaw * 256.0F / 360.0F));
+         this.g = (byte) ((int) (pitch * 256.0F / 360.0F));
+-        this.j = metadata;
+         this.h = heldItem == null ? 0 : Item.getId(heldItem.getItem());
++        this.i = dataWatcher;
++        this.j = dataWatcher.b();
+     }
+     // SportPaper end
+     public PacketPlayOutNamedEntitySpawn() {}
+-- 
+2.17.1
+


### PR DESCRIPTION
Fixes an error in the `PacketPlayOutNamedEntitySpawn` class where the data watcher is not initialized inside the constructor causing a `NullPointerException`