### PR TITLE
Allow plugins to append custom data in server ping

### DIFF
--- a/patches/api/0098-Allow-plugins-to-append-custom-data-in-server-ping.patch
+++ b/patches/api/0098-Allow-plugins-to-append-custom-data-in-server-ping.patch
@@ -1,0 +1,90 @@
+From ce2cbe8f8cece4b45608fa73de2ff695a5f0a55b Mon Sep 17 00:00:00 2001
+From: TheMolkaPL <themolkapl@gmail.com>
+Date: Tue, 31 Dec 2019 03:02:34 +0100
+Subject: [PATCH] Allow plugins to append custom data in server ping
+
+Signed-off-by: TheMolkaPL <themolkapl@gmail.com>
+
+diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+index 3c38d857..215e5e08 100644
+--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
++++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+@@ -1,11 +1,17 @@
+ package org.bukkit.event.server;
+ 
+ import java.net.InetAddress;
++import java.util.Collections;
++import java.util.HashMap;
+ import java.util.Iterator;
++import java.util.Map;
++import java.util.Optional;
+ 
++import com.google.gson.JsonObject;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.HandlerList;
++import org.bukkit.plugin.Plugin;
+ import org.bukkit.util.CachedServerIcon;
+ 
+ /**
+@@ -19,6 +25,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+     private String motd;
+     private final int numPlayers;
+     private int maxPlayers;
++    private final Map<Plugin, JsonObject> extras = new HashMap<>();
+ 
+     public ServerListPingEvent(final InetAddress address, final String motd, final int numPlayers, final int maxPlayers) {
+         super(); // Paper - Is this event being fired async?
+@@ -107,6 +114,49 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+         this.maxPlayers = maxPlayers;
+     }
+ 
++    /**
++     * Get or create a new {@link JsonObject} representing extra data provided
++     * by the given plugin.
++     *
++     * @see #getExtra(Plugin)
++     * @see #getExtras()
++     * @param owningPlugin owner of the data
++     * @return existing {@link JsonObject} or a new one if it doesn't exist
++     */
++    public JsonObject getOrCreateExtra(Plugin owningPlugin) {
++        Validate.notNull(owningPlugin, "owningPlugin");
++        return getExtra(owningPlugin).orElseGet(() -> {
++            JsonObject object = new JsonObject();
++            extras.put(owningPlugin, object);
++            return object;
++        });
++    }
++
++    /**
++     * Get {@link JsonObject} representing extra data provided by the given
++     * plugin.
++     *
++     * @see #getOrCreateExtra(Plugin)
++     * @see #getExtras()
++     * @param owningPlugin owner of the data
++     * @return existing {@link JsonObject} or {@link Optional#empty()}
++     */
++    public Optional<JsonObject> getExtra(Plugin owningPlugin) {
++        Validate.notNull(owningPlugin, "owningPlugin");
++        return Optional.ofNullable(extras.get(owningPlugin));
++    }
++
++    /**
++     * Get all existing extras in this event.
++     *
++     * @see #getOrCreateExtra(Plugin)
++     * @see #getExtra(Plugin)
++     * @return unmodifiable current extras
++     */
++    public Map<Plugin, JsonObject> getExtras() {
++        return Collections.unmodifiableMap(extras);
++    }
++
+     /**
+      * Sets the server-icon sent to the client.
+      *
+-- 
+2.23.0.windows.1
+

--- a/patches/server/0184-Allow-plugins-to-append-custom-data-in-server-ping.patch
+++ b/patches/server/0184-Allow-plugins-to-append-custom-data-in-server-ping.patch
@@ -1,0 +1,148 @@
+From dd25fb04cc69c8cee8b15091c72d09ec4c523bc6 Mon Sep 17 00:00:00 2001
+From: TheMolkaPL <themolkapl@gmail.com>
+Date: Tue, 31 Dec 2019 03:07:18 +0100
+Subject: [PATCH] Allow plugins to append custom data in server ping
+
+Signed-off-by: TheMolkaPL <themolkapl@gmail.com>
+
+diff --git a/src/main/java/net/minecraft/server/PacketStatusListener.java b/src/main/java/net/minecraft/server/PacketStatusListener.java
+index e4bff04a..770fd53a 100644
+--- a/src/main/java/net/minecraft/server/PacketStatusListener.java
++++ b/src/main/java/net/minecraft/server/PacketStatusListener.java
+@@ -5,6 +5,7 @@ import com.mojang.authlib.GameProfile;
+ import io.netty.channel.ChannelFutureListener;
+ import java.net.InetSocketAddress;
+ import java.util.Iterator;
++import java.util.Locale; // SportPaper - server list ping extra
+ 
+ import org.bukkit.craftbukkit.util.CraftIconCache;
+ import org.bukkit.entity.Player;
+@@ -123,6 +124,14 @@ public class PacketStatusListener implements PacketStatusInListener {
+         ping.setPlayerSample(playerSample);
+         ping.setServerInfo(new ServerPing.ServerData(minecraftServer.getServerModName() + " " + minecraftServer.getVersion(), 47)); // TODO: Update when protocol changes
+ 
++        // SportPaper start - append extras
++        event.getExtras().forEach((plugin, object) -> {
++            if (!object.entrySet().isEmpty()) {
++                ping.getExtra().putIfAbsent(plugin.getName().toLowerCase(Locale.ROOT), object);
++            }
++        });
++        // SportPaper end
++
+         this.networkManager.handle(new PacketStatusOutServerInfo(ping));
+         // CraftBukkit end
+     }
+diff --git a/src/main/java/net/minecraft/server/ServerPing.java b/src/main/java/net/minecraft/server/ServerPing.java
+index 034a559b..3f471702 100644
+--- a/src/main/java/net/minecraft/server/ServerPing.java
++++ b/src/main/java/net/minecraft/server/ServerPing.java
+@@ -12,12 +12,19 @@ import com.mojang.authlib.GameProfile;
+ import java.lang.reflect.Type;
+ import java.util.UUID;
+ 
++// SportPaper start
++import java.util.Locale;
++import java.util.Map;
++import java.util.HashMap;
++// SportPaper end
++
+ public class ServerPing {
+ 
+     private IChatBaseComponent a;
+     private ServerPing.ServerPingPlayerSample b;
+     private ServerPing.ServerData c;
+     private String d;
++    private final Map<String, JsonObject> extra = new HashMap<>(); // SportPaper - extra
+ 
+     public ServerPing() {}
+ 
+@@ -53,6 +60,13 @@ public class ServerPing {
+         return this.d;
+     }
+ 
++    // SportPaper start - getter for extra
++    // NOTE: keys are plugin names in lower case, same as in NamespacedKey
++    public Map<String, JsonObject> getExtra() {
++        return this.extra;
++    }
++    // SportPaper end
++
+     public static class Serializer implements JsonDeserializer<ServerPing>, JsonSerializer<ServerPing> {
+ 
+         public Serializer() {}
+@@ -77,6 +91,14 @@ public class ServerPing {
+                 serverping.setFavicon(ChatDeserializer.h(jsonobject, "favicon"));
+             }
+ 
++            // SportPaper start - deserialize extra
++            if (jsonobject.has("bukkit_extra")) {
++                jsonobject.getAsJsonObject("bukkit_extra").entrySet().forEach(entry -> {
++                    serverping.extra.putIfAbsent(entry.getKey(), entry.getValue().getAsJsonObject());
++                });
++            }
++            // SportPaper end
++
+             return serverping;
+         }
+ 
+@@ -99,14 +121,27 @@ public class ServerPing {
+                 jsonobject.addProperty("favicon", serverping.d());
+             }
+ 
++            // SportPaper start - serialize extra
++            JsonObject serializedExtra = new JsonObject();
++            serverping.extra.forEach((pluginName, jsonObject) -> {
++                if (!jsonObject.entrySet().isEmpty()) {
++                    serializedExtra.add(pluginName, jsonObject);
++                }
++            });
++
++            if (!serializedExtra.entrySet().isEmpty()) {
++                jsonobject.add("bukkit_extra", serializedExtra);
++            }
++            // SportPaper end
++
+             return jsonobject;
+         }
+ 
+-        public JsonElement serialize(Object object, Type type, JsonSerializationContext jsonserializationcontext) {
++        public JsonElement serialize(ServerPing object, Type type, JsonSerializationContext jsonserializationcontext) { // SportPaper - compile error
+             return this.a((ServerPing) object, type, jsonserializationcontext);
+         }
+ 
+-        public Object deserialize(JsonElement jsonelement, Type type, JsonDeserializationContext jsondeserializationcontext) throws JsonParseException {
++        public ServerPing deserialize(JsonElement jsonelement, Type type, JsonDeserializationContext jsondeserializationcontext) throws JsonParseException { // SportPaper - compile error
+             return this.a(jsonelement, type, jsondeserializationcontext);
+         }
+     }
+@@ -147,11 +182,11 @@ public class ServerPing {
+                 return jsonobject;
+             }
+ 
+-            public JsonElement serialize(Object object, Type type, JsonSerializationContext jsonserializationcontext) {
++            public JsonElement serialize(ServerPing.ServerData object, Type type, JsonSerializationContext jsonserializationcontext) { // SportPaper - compile error
+                 return this.a((ServerPing.ServerData) object, type, jsonserializationcontext);
+             }
+ 
+-            public Object deserialize(JsonElement jsonelement, Type type, JsonDeserializationContext jsondeserializationcontext) throws JsonParseException {
++            public ServerPing.ServerData deserialize(JsonElement jsonelement, Type type, JsonDeserializationContext jsondeserializationcontext) throws JsonParseException { // SportPaper - compile error
+                 return this.a(jsonelement, type, jsondeserializationcontext);
+             }
+         }
+@@ -235,11 +270,11 @@ public class ServerPing {
+                 return jsonobject;
+             }
+ 
+-            public JsonElement serialize(Object object, Type type, JsonSerializationContext jsonserializationcontext) {
++            public JsonElement serialize(ServerPing.ServerPingPlayerSample object, Type type, JsonSerializationContext jsonserializationcontext) { // SportPaper - compile error
+                 return this.a((ServerPing.ServerPingPlayerSample) object, type, jsonserializationcontext);
+             }
+ 
+-            public Object deserialize(JsonElement jsonelement, Type type, JsonDeserializationContext jsondeserializationcontext) throws JsonParseException {
++            public ServerPing.ServerPingPlayerSample deserialize(JsonElement jsonelement, Type type, JsonDeserializationContext jsondeserializationcontext) throws JsonParseException { // SportPaper - compile error
+                 return this.a(jsonelement, type, jsondeserializationcontext);
+             }
+         }
+-- 
+2.23.0.windows.1
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -53,6 +53,7 @@ import StatisticList
 import PacketPlayOutSpawnEntity
 import ItemGoldenApple
 import ItemPotion
+import ServerPing
 import WorldGenCaves
 import WorldSettings
 


### PR DESCRIPTION
This will allow [PGM](https://github.com/Electroid/PGM) to expose extra information, such as current and next map, or amount of participating and observing players. Might be useful for the oc.tc website showing current and next map, or custom clients.

Related: https://github.com/ProjectEnyo/projectenyo.github.io/pull/4#issuecomment-569471250