### PR TITLE
Speed up chunk unloading

### DIFF
--- a/patches/server/0185-Speed-up-chunk-unloading.patch
+++ b/patches/server/0185-Speed-up-chunk-unloading.patch
@@ -1,0 +1,76 @@
+From f326bb52cc772753bbe01fbec2ee05ab937ae0a6 Mon Sep 17 00:00:00 2001
+From: Austin Mayes <austin@avicus.net>
+Date: Fri, 14 Feb 2020 18:11:36 -0600
+Subject: [PATCH] Speed up chunk unloading
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+index 775cbd48..df837d95 100644
+--- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
++++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+@@ -9,7 +9,7 @@ import java.util.List;
+ import java.util.Set;
+ import java.util.concurrent.ConcurrentHashMap;
+ 
+-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
++import it.unimi.dsi.fastutil.longs.*;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+@@ -28,17 +28,13 @@ import org.github.paperspigot.event.ServerExceptionEvent;
+ import org.github.paperspigot.exception.ServerInternalException;
+ // CraftBukkit end
+ // SportPaper start
+-import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+-import it.unimi.dsi.fastutil.longs.LongArraySet;
+-import it.unimi.dsi.fastutil.longs.LongIterator;
+-import it.unimi.dsi.fastutil.longs.LongSet;
+ // SportPaper end
+ 
+ public class ChunkProviderServer implements IChunkProvider {
+ 
+     private static final Logger b = LogManager.getLogger();
+-    public LongSet unloadQueue = new LongArraySet(); // SportPaper
++    public LongSet unloadQueue = new LongOpenHashSet(20); // SportPaper
+     public Chunk emptyChunk;
+     public IChunkProvider chunkProvider;
+     private IChunkLoader chunkLoader;
+@@ -408,6 +404,10 @@ public class ChunkProviderServer implements IChunkProvider {
+     }
+ 
+     public void unloadChunk(Chunk chunk) {
++        unloadChunk(chunk, false);
++    }
++
++    private void unloadChunk(Chunk chunk, boolean auto) {
+         Server server = this.world.getServer();
+         ChunkUnloadEvent event = new ChunkUnloadEvent(chunk.bukkitChunk);
+         server.getPluginManager().callEvent(event);
+@@ -417,7 +417,7 @@ public class ChunkProviderServer implements IChunkProvider {
+             this.saveChunk(chunk);
+             this.saveChunkNOP(chunk);
+             this.chunks.remove(chunk.chunkKey); // CraftBukkit
+-            if (this.unloadQueue.contains(chunk.chunkKey)) {
++            if (!auto && this.unloadQueue.contains(chunk.chunkKey)) {
+                 this.unloadQueue.remove(chunk.chunkKey);
+             }
+ 
+@@ -446,12 +446,12 @@ public class ChunkProviderServer implements IChunkProvider {
+             // SportPaper start
+             LongIterator iterator = unloadQueue.iterator();
+             for (int i = 0; i < 100 && iterator.hasNext(); ++i) {
+-                long chunkcoordinates = iterator.next();
++                long chunkcoordinates = iterator.nextLong();
+                 iterator.remove();
+                 // SportPaper end
+                 Chunk chunk = this.chunks.get(chunkcoordinates);
+                 if (chunk == null) continue;
+-                unloadChunk(chunk); // SportPaper - Move to own method
++                unloadChunk(chunk, true); // SportPaper - Move to own method
+             }
+             // CraftBukkit end
+ 
+-- 
+2.23.0
+

--- a/patches/server/0185-Speed-up-chunk-unloading.patch
+++ b/patches/server/0185-Speed-up-chunk-unloading.patch
@@ -1,31 +1,50 @@
-From 53f4d7358181c42a28c36d949cf87d8160461d36 Mon Sep 17 00:00:00 2001
+From a0cacec226ab8c0829a03d649abce8f8d3535de9 Mon Sep 17 00:00:00 2001
 From: Austin Mayes <austin@avicus.net>
 Date: Fri, 14 Feb 2020 18:11:36 -0600
 Subject: [PATCH] Speed up chunk unloading
 
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 775cbd48..a9720aa6 100644
+index 775cbd48..812686d5 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -9,7 +9,7 @@ import java.util.List;
- import java.util.Set;
- import java.util.concurrent.ConcurrentHashMap;
+@@ -1,28 +1,19 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.collect.Lists;
+ import java.io.IOException;
+-import java.util.ArrayList;
+-import java.util.Collections;
+ import java.util.Iterator;
+ import java.util.List;
+-import java.util.Set;
+-import java.util.concurrent.ConcurrentHashMap;
  
 -import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-+import it.unimi.dsi.fastutil.longs.*;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
-@@ -28,17 +28,13 @@ import org.github.paperspigot.event.ServerExceptionEvent;
+ // CraftBukkit start
+ import java.util.Random;
+-import java.util.logging.Level;
+ 
+ import org.bukkit.Bukkit;
+ import org.bukkit.Server;
+ import org.bukkit.craftbukkit.chunkio.ChunkIOExecutor;
+ import org.bukkit.craftbukkit.util.LongHash;
+-import org.bukkit.craftbukkit.util.LongHashSet;
+-import org.bukkit.craftbukkit.util.LongObjectHashMap;
+ import org.bukkit.event.world.ChunkUnloadEvent;
+ import org.github.paperspigot.event.ServerExceptionEvent;
  import org.github.paperspigot.exception.ServerInternalException;
- // CraftBukkit end
+@@ -30,15 +21,15 @@ import org.github.paperspigot.exception.ServerInternalException;
  // SportPaper start
--import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
  import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 -import it.unimi.dsi.fastutil.longs.LongArraySet;
--import it.unimi.dsi.fastutil.longs.LongIterator;
--import it.unimi.dsi.fastutil.longs.LongSet;
+ import it.unimi.dsi.fastutil.longs.LongIterator;
++import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+ import it.unimi.dsi.fastutil.longs.LongSet;
  // SportPaper end
  
  public class ChunkProviderServer implements IChunkProvider {
@@ -36,7 +55,7 @@ index 775cbd48..a9720aa6 100644
      public Chunk emptyChunk;
      public IChunkProvider chunkProvider;
      private IChunkLoader chunkLoader;
-@@ -152,7 +148,6 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -152,7 +143,6 @@ public class ChunkProviderServer implements IChunkProvider {
      }
  
      public Chunk getChunkAt(int i, int j, Runnable runnable) {
@@ -44,7 +63,7 @@ index 775cbd48..a9720aa6 100644
          Chunk chunk = chunks.get(LongHash.toLong(i, j));
          ChunkRegionLoader loader = null;
  
-@@ -172,6 +167,7 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -172,6 +162,7 @@ public class ChunkProviderServer implements IChunkProvider {
              chunk = originalGetChunkAt(i, j);
          }
  
@@ -52,7 +71,7 @@ index 775cbd48..a9720aa6 100644
          // If we didn't load the chunk async and have a callback run it now
          if (runnable != null) {
              runnable.run();
-@@ -180,7 +176,6 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -180,7 +171,6 @@ public class ChunkProviderServer implements IChunkProvider {
          return chunk;
      }
      public Chunk originalGetChunkAt(int i, int j) {
@@ -60,7 +79,7 @@ index 775cbd48..a9720aa6 100644
          Chunk chunk = (Chunk) this.chunks.get(LongHash.toLong(i, j));
          boolean newChunk = false;
          // CraftBukkit end
-@@ -241,6 +236,7 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -241,6 +231,7 @@ public class ChunkProviderServer implements IChunkProvider {
              world.timings.syncChunkLoadTimer.stopTiming(); // Spigot
          }
  
@@ -68,7 +87,7 @@ index 775cbd48..a9720aa6 100644
          return chunk;
      }
  
-@@ -408,6 +404,10 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -408,6 +399,10 @@ public class ChunkProviderServer implements IChunkProvider {
      }
  
      public void unloadChunk(Chunk chunk) {
@@ -79,7 +98,7 @@ index 775cbd48..a9720aa6 100644
          Server server = this.world.getServer();
          ChunkUnloadEvent event = new ChunkUnloadEvent(chunk.bukkitChunk);
          server.getPluginManager().callEvent(event);
-@@ -417,7 +417,7 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -417,7 +412,7 @@ public class ChunkProviderServer implements IChunkProvider {
              this.saveChunk(chunk);
              this.saveChunkNOP(chunk);
              this.chunks.remove(chunk.chunkKey); // CraftBukkit
@@ -88,7 +107,7 @@ index 775cbd48..a9720aa6 100644
                  this.unloadQueue.remove(chunk.chunkKey);
              }
  
-@@ -446,12 +446,12 @@ public class ChunkProviderServer implements IChunkProvider {
+@@ -446,12 +441,12 @@ public class ChunkProviderServer implements IChunkProvider {
              // SportPaper start
              LongIterator iterator = unloadQueue.iterator();
              for (int i = 0; i < 100 && iterator.hasNext(); ++i) {

--- a/patches/server/0185-Speed-up-chunk-unloading.patch
+++ b/patches/server/0185-Speed-up-chunk-unloading.patch
@@ -1,11 +1,11 @@
-From f326bb52cc772753bbe01fbec2ee05ab937ae0a6 Mon Sep 17 00:00:00 2001
+From 53f4d7358181c42a28c36d949cf87d8160461d36 Mon Sep 17 00:00:00 2001
 From: Austin Mayes <austin@avicus.net>
 Date: Fri, 14 Feb 2020 18:11:36 -0600
 Subject: [PATCH] Speed up chunk unloading
 
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 775cbd48..df837d95 100644
+index 775cbd48..a9720aa6 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -9,7 +9,7 @@ import java.util.List;
@@ -36,6 +36,38 @@ index 775cbd48..df837d95 100644
      public Chunk emptyChunk;
      public IChunkProvider chunkProvider;
      private IChunkLoader chunkLoader;
+@@ -152,7 +148,6 @@ public class ChunkProviderServer implements IChunkProvider {
+     }
+ 
+     public Chunk getChunkAt(int i, int j, Runnable runnable) {
+-        unloadQueue.remove(LongHash.toLong(i, j)); // SportPaper
+         Chunk chunk = chunks.get(LongHash.toLong(i, j));
+         ChunkRegionLoader loader = null;
+ 
+@@ -172,6 +167,7 @@ public class ChunkProviderServer implements IChunkProvider {
+             chunk = originalGetChunkAt(i, j);
+         }
+ 
++        unloadQueue.remove(LongHash.toLong(i, j)); // SportPaper
+         // If we didn't load the chunk async and have a callback run it now
+         if (runnable != null) {
+             runnable.run();
+@@ -180,7 +176,6 @@ public class ChunkProviderServer implements IChunkProvider {
+         return chunk;
+     }
+     public Chunk originalGetChunkAt(int i, int j) {
+-        this.unloadQueue.remove(LongHash.toLong(i, j)); // SportPaper
+         Chunk chunk = (Chunk) this.chunks.get(LongHash.toLong(i, j));
+         boolean newChunk = false;
+         // CraftBukkit end
+@@ -241,6 +236,7 @@ public class ChunkProviderServer implements IChunkProvider {
+             world.timings.syncChunkLoadTimer.stopTiming(); // Spigot
+         }
+ 
++        this.unloadQueue.remove(LongHash.toLong(i, j)); // SportPaper
+         return chunk;
+     }
+ 
 @@ -408,6 +404,10 @@ public class ChunkProviderServer implements IChunkProvider {
      }
  
@@ -70,6 +102,26 @@ index 775cbd48..df837d95 100644
 +                unloadChunk(chunk, true); // SportPaper - Move to own method
              }
              // CraftBukkit end
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 87cb3be2..b2eaf0c7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -338,7 +338,6 @@ public class CraftWorld implements World {
+             return world.chunkProviderServer.getChunkAt(x, z) != null;
+         }
+ 
+-        world.chunkProviderServer.unloadQueue.remove(LongHash.toLong(x, z));
+         net.minecraft.server.Chunk chunk = world.chunkProviderServer.chunks.get(LongHash.toLong(x, z));
+ 
+         if (chunk == null) {
+@@ -348,6 +347,7 @@ public class CraftWorld implements World {
+             chunkLoadPostProcess(chunk, x, z);
+             world.timings.syncChunkLoadTimer.stopTiming(); // Spigot
+         }
++        world.chunkProviderServer.unloadQueue.remove(LongHash.toLong(x, z));
+         return chunk != null;
+     }
  
 -- 
 2.23.0


### PR DESCRIPTION
- Changes unload queue to a [LongOpenHashSet](http://fastutil.di.unimi.it/docs/it/unimi/dsi/fastutil/longs/LongOpenHashSet.html)
- Removes some redundant queue checks. 
- Moves some unload queue checks out of places where the chunk would never be in the queue to begin with. 