### PR TITLE
Add option to remove randomness in arrow damage

### DIFF
--- a/patches/server/0190-Add-option-to-remove-randomness-in-arrow-damage.patch
+++ b/patches/server/0190-Add-option-to-remove-randomness-in-arrow-damage.patch
@@ -1,0 +1,37 @@
+From b4315ee1e6a5261767ae90cb489747020553c07f Mon Sep 17 00:00:00 2001
+From: Indicado <indicado@walrus.gg>
+Date: Wed, 15 Jul 2020 09:52:19 +0200
+Subject: [PATCH] Add option to remove randomness in arrow damage
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
+index 4366f34b..dd903aa7 100644
+--- a/src/main/java/net/minecraft/server/EntityArrow.java
++++ b/src/main/java/net/minecraft/server/EntityArrow.java
+@@ -247,7 +247,7 @@ public class EntityArrow extends Entity implements IProjectile {
+                     f2 = MathHelper.sqrt(this.motX * this.motX + this.motY * this.motY + this.motZ * this.motZ);
+                     int k = MathHelper.f((double) f2 * this.damage);
+
+-                    if (this.isCritical()) {
++                    if (this.isCritical() && PaperSpigotConfig.includeRandomnessInArrowDamage) { // SportPaper
+                         k += this.random.nextInt(k / 2 + 2);
+                     }
+
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index 038137dc..e963207e 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -118,6 +118,11 @@ public class PaperSpigotConfig
+         includeRandomnessInArrowTrajectory = getBoolean("settings.include-randomness-in-arrow-trajectory", includeRandomnessInArrowTrajectory);
+     }
+
++    public static boolean includeRandomnessInArrowDamage = true;
++    private static void includeRandomnessInArrowDamage() {
++        includeRandomnessInArrowDamage = getBoolean("settings.include-randomness-in-arrow-damage", includeRandomnessInArrowDamage);
++    }
++
+     public static boolean tickEmptyWorlds = true;
+     private static void tickEmptyWorlds() {
+         tickEmptyWorlds = getBoolean("settings.tick-empty-worlds", tickEmptyWorlds);
+--
+2.25.1

--- a/sportpaper.yml
+++ b/sportpaper.yml
@@ -393,6 +393,9 @@ paper:
     # Whether arrow projectiles should have a random factor.
     include-randomness-in-arrow-trajectory: false
 
+    # Whether arrow projectiles should add a random amount of damage (like in vanilla minecraft)
+    include-randomness-in-arrow-damage: true
+
     # Number of ticks between player data saves to disk.
     player-auto-save-rate: -1
 


### PR DESCRIPTION
What the title says. The option is disabled by default (just so existing SportPaper servers don't see their behavior changed) but can be enabled by changing `include-randomness-in-arrow-damage: true` to `include-randomness-in-arrow-damage: false`. Here's a demonstration:

With randomness in arrow damage: https://i.imgur.com/Rpf5ZRE.gif
Without randomness in arrow damage: https://i.imgur.com/rg8rZyT.gif

Full credit to @mattarnold98, author of the [original patch](https://github.com/WalrusNetwork/SportPaper/commit/dacb01f2856a190e4b04fcf017b9d4d5d332832b) in the Stratus/Walrus SportPaper.

Signed-off-by: Indicado <indicado@walrus.gg>