### PR TITLE
Make unknown command and internal error messages customisable

### DIFF
--- a/patches/api/0101-Make-unknown-and-internal-command-messages-customisa.patch
+++ b/patches/api/0101-Make-unknown-and-internal-command-messages-customisa.patch
@@ -1,0 +1,79 @@
+From 07ceba66de58bfb7ee13fbc60e54323d1639ed6f Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Fri, 4 Dec 2020 13:56:52 +0200
+Subject: [PATCH] Make unknown and internal command messages customisable in
+ PlayerCommandPreprocessEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+index 1ec81732..7a71ac45 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+@@ -48,7 +48,7 @@ import org.bukkit.event.HandlerList;
+ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private boolean cancel = false;
+-    private String message;
++    private String message, unknownCommandMessage, internalErrorMessage;
+     private String format = "<%1$s> %2$s";
+     private final Set<Player> recipients;
+ 
+@@ -64,6 +64,12 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
+         this.message = message;
+     }
+ 
++    public PlayerCommandPreprocessEvent(final Player player, final String message, final Set<Player> recipients, final String unknownCommandMessage, final String internalErrorMessage) {
++        this(player, message, recipients);
++        this.unknownCommandMessage = unknownCommandMessage;
++        this.internalErrorMessage = internalErrorMessage;
++    }
++
+     public boolean isCancelled() {
+         return cancel;
+     }
+@@ -99,6 +105,42 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
+         this.message = command;
+     }
+ 
++    /**
++     * Gets the message that the player will receive if the command wasn't found.
++     *
++     * @return message that the player will receive if the command wasn't found. May be null.
++     */
++    public String getUnknownCommandMessage() {
++        return unknownCommandMessage;
++    }
++
++    /**
++     * Sets the message that the player will receive if the command wasn't found.
++     *
++     * @param unknownCommandMessage new message that the player will receive if the command wasn't found. null if no message should be sent.
++     */
++    public void setUnknownCommandMessage(String unknownCommandMessage) {
++        this.unknownCommandMessage = unknownCommandMessage;
++    }
++
++    /**
++     * Gets the message that the player will receive if an internal error occurred.
++     *
++     * @return message that the player will receive if an internal error occurred. May be null.
++     */
++    public String getInternalErrorMessage() {
++        return internalErrorMessage;
++    }
++
++    /**
++     * Sets the message that the player will receive if an internal error occurred.
++     *
++     * @param internalErrorMessage new message that the player will receive if an internal error occurred. null if no message should be sent.
++     */
++    public void setInternalErrorMessage(String internalErrorMessage) {
++        this.internalErrorMessage = internalErrorMessage;
++    }
++
+     /**
+      * Sets the player that this command will be executed as.
+      *
+-- 
+2.25.1
+

--- a/patches/api/0101-Make-unknown-and-internal-command-messages-customisa.patch
+++ b/patches/api/0101-Make-unknown-and-internal-command-messages-customisa.patch
@@ -1,4 +1,4 @@
-From 07ceba66de58bfb7ee13fbc60e54323d1639ed6f Mon Sep 17 00:00:00 2001
+From cf4e5aab74629c3d8e822c36d96190c87fc72f47 Mon Sep 17 00:00:00 2001
 From: VytskaLT <VytskaLT@protonmail.com>
 Date: Fri, 4 Dec 2020 13:56:52 +0200
 Subject: [PATCH] Make unknown and internal command messages customisable in
@@ -6,7 +6,7 @@ Subject: [PATCH] Make unknown and internal command messages customisable in
 
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
-index 1ec81732..7a71ac45 100644
+index 1ec81732..649b5654 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
 @@ -48,7 +48,7 @@ import org.bukkit.event.HandlerList;
@@ -31,14 +31,14 @@ index 1ec81732..7a71ac45 100644
      public boolean isCancelled() {
          return cancel;
      }
-@@ -99,6 +105,42 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
+@@ -99,6 +105,48 @@ public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancell
          this.message = command;
      }
  
 +    /**
 +     * Gets the message that the player will receive if the command wasn't found.
 +     *
-+     * @return message that the player will receive if the command wasn't found. May be null.
++     * @return message that the player will receive if the command wasn't found.
 +     */
 +    public String getUnknownCommandMessage() {
 +        return unknownCommandMessage;
@@ -47,16 +47,19 @@ index 1ec81732..7a71ac45 100644
 +    /**
 +     * Sets the message that the player will receive if the command wasn't found.
 +     *
-+     * @param unknownCommandMessage new message that the player will receive if the command wasn't found. null if no message should be sent.
++     * @param unknownCommandMessage new message that the player will receive if the command wasn't found.
++     * @throws IllegalArgumentException if unknown command message is null or empty
 +     */
-+    public void setUnknownCommandMessage(String unknownCommandMessage) {
++    public void setUnknownCommandMessage(String unknownCommandMessage) throws IllegalArgumentException {
++        Validate.notNull(unknownCommandMessage, "Unknown command message cannot be null");
++        Validate.notEmpty(unknownCommandMessage, "Unknown command message cannot be empty");
 +        this.unknownCommandMessage = unknownCommandMessage;
 +    }
 +
 +    /**
 +     * Gets the message that the player will receive if an internal error occurred.
 +     *
-+     * @return message that the player will receive if an internal error occurred. May be null.
++     * @return message that the player will receive if an internal error occurred.
 +     */
 +    public String getInternalErrorMessage() {
 +        return internalErrorMessage;
@@ -65,9 +68,12 @@ index 1ec81732..7a71ac45 100644
 +    /**
 +     * Sets the message that the player will receive if an internal error occurred.
 +     *
-+     * @param internalErrorMessage new message that the player will receive if an internal error occurred. null if no message should be sent.
++     * @param internalErrorMessage new message that the player will receive if an internal error occurred.
++     * @throws IllegalArgumentException if internal error message is null or empty
 +     */
-+    public void setInternalErrorMessage(String internalErrorMessage) {
++    public void setInternalErrorMessage(String internalErrorMessage) throws IllegalArgumentException {
++        Validate.notNull(internalErrorMessage, "Internal error message cannot be null");
++        Validate.notEmpty(internalErrorMessage, "Internal error message cannot be empty");
 +        this.internalErrorMessage = internalErrorMessage;
 +    }
 +

--- a/patches/server/0193-Make-unknown-and-internal-command-messages-customisa.patch
+++ b/patches/server/0193-Make-unknown-and-internal-command-messages-customisa.patch
@@ -1,4 +1,4 @@
-From 5db380e00a883c2dbff5747ab8690e5cc0f3836d Mon Sep 17 00:00:00 2001
+From 33caddfe2015b8ad3ace67d7b9a78cd9d55bb0f7 Mon Sep 17 00:00:00 2001
 From: VytskaLT <VytskaLT@protonmail.com>
 Date: Fri, 4 Dec 2020 13:56:51 +0200
 Subject: [PATCH] Make unknown and internal command messages customisable in
@@ -6,62 +6,70 @@ Subject: [PATCH] Make unknown and internal command messages customisable in
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 21747b92..66e17ecd 100644
+index 21747b92..cd984175 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1319,7 +1319,9 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -1319,7 +1319,10 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
  
          CraftPlayer player = this.getPlayer();
  
 -        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, s, new LazyPlayerSet());
++        // SportPaper - make unknown command and internal error messages customisable
 +        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, s, new LazyPlayerSet(),
 +                org.spigotmc.SpigotConfig.unknownCommandMessage,
 +                org.bukkit.ChatColor.RED + "An internal error occurred while attempting to perform this command");
          this.server.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
-@@ -1328,12 +1330,14 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -1328,12 +1331,16 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
          }
  
          try {
 -            if (this.server.dispatchCommand(event.getPlayer(), event.getMessage().substring(1))) {
-+            if (this.server.dispatchCommand(event.getPlayer(), event.getMessage().substring(1), event.getUnknownCommandMessage())) {
++            if (this.server.dispatchCommand(event.getPlayer(), event.getMessage().substring(1), event.getUnknownCommandMessage())) { // SportPaper
                  SpigotTimings.playerCommandTimer.stopTiming(); // Spigot
                  return;
              }
          } catch (org.bukkit.command.CommandException ex) {
 -            player.sendMessage(org.bukkit.ChatColor.RED + "An internal error occurred while attempting to perform this command");
++            // SportPaper start
 +            if (event.getInternalErrorMessage() != null) {
 +                player.sendMessage(event.getInternalErrorMessage());
 +            }
++            // SportPaper end
              java.util.logging.Logger.getLogger(PlayerConnection.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              SpigotTimings.playerCommandTimer.stopTiming(); // Spigot
              return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 613582cc..c55a134d 100644
+index 613582cc..e4aab51d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -620,7 +620,11 @@ public final class CraftServer implements Server {
+@@ -619,8 +619,14 @@ public final class CraftServer implements Server {
+         }
      }
  
++    // SportPaper start
      @Override
 -    public boolean dispatchCommand(CommandSender sender, String commandLine) {
 +    public boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandException {
 +        return dispatchCommand(sender, commandLine, org.spigotmc.SpigotConfig.unknownCommandMessage);
 +    }
++    // SportPaper end
 +
-+    public boolean dispatchCommand(CommandSender sender, String commandLine, String unknownCommandMessage) {
++    public boolean dispatchCommand(CommandSender sender, String commandLine, String unknownCommandMessage) { // SportPaper - make unknown command message customisable
          Validate.notNull(sender, "Sender cannot be null");
          Validate.notNull(commandLine, "CommandLine cannot be null");
  
-@@ -651,7 +655,9 @@ public final class CraftServer implements Server {
+@@ -651,7 +657,11 @@ public final class CraftServer implements Server {
              return true;
          }
  
 -        sender.sendMessage(org.spigotmc.SpigotConfig.unknownCommandMessage);
++        // SportPaper start
 +        if (unknownCommandMessage != null) {
 +            sender.sendMessage(unknownCommandMessage);
 +        }
++        // SportPaper end
  
          return false;
      }

--- a/patches/server/0193-Make-unknown-and-internal-command-messages-customisa.patch
+++ b/patches/server/0193-Make-unknown-and-internal-command-messages-customisa.patch
@@ -1,0 +1,70 @@
+From 5db380e00a883c2dbff5747ab8690e5cc0f3836d Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Fri, 4 Dec 2020 13:56:51 +0200
+Subject: [PATCH] Make unknown and internal command messages customisable in
+ PlayerCommandPreprocessEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 21747b92..66e17ecd 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1319,7 +1319,9 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+ 
+         CraftPlayer player = this.getPlayer();
+ 
+-        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, s, new LazyPlayerSet());
++        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, s, new LazyPlayerSet(),
++                org.spigotmc.SpigotConfig.unknownCommandMessage,
++                org.bukkit.ChatColor.RED + "An internal error occurred while attempting to perform this command");
+         this.server.getPluginManager().callEvent(event);
+ 
+         if (event.isCancelled()) {
+@@ -1328,12 +1330,14 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+         }
+ 
+         try {
+-            if (this.server.dispatchCommand(event.getPlayer(), event.getMessage().substring(1))) {
++            if (this.server.dispatchCommand(event.getPlayer(), event.getMessage().substring(1), event.getUnknownCommandMessage())) {
+                 SpigotTimings.playerCommandTimer.stopTiming(); // Spigot
+                 return;
+             }
+         } catch (org.bukkit.command.CommandException ex) {
+-            player.sendMessage(org.bukkit.ChatColor.RED + "An internal error occurred while attempting to perform this command");
++            if (event.getInternalErrorMessage() != null) {
++                player.sendMessage(event.getInternalErrorMessage());
++            }
+             java.util.logging.Logger.getLogger(PlayerConnection.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+             SpigotTimings.playerCommandTimer.stopTiming(); // Spigot
+             return;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 613582cc..c55a134d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -620,7 +620,11 @@ public final class CraftServer implements Server {
+     }
+ 
+     @Override
+-    public boolean dispatchCommand(CommandSender sender, String commandLine) {
++    public boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandException {
++        return dispatchCommand(sender, commandLine, org.spigotmc.SpigotConfig.unknownCommandMessage);
++    }
++
++    public boolean dispatchCommand(CommandSender sender, String commandLine, String unknownCommandMessage) {
+         Validate.notNull(sender, "Sender cannot be null");
+         Validate.notNull(commandLine, "CommandLine cannot be null");
+ 
+@@ -651,7 +655,9 @@ public final class CraftServer implements Server {
+             return true;
+         }
+ 
+-        sender.sendMessage(org.spigotmc.SpigotConfig.unknownCommandMessage);
++        if (unknownCommandMessage != null) {
++            sender.sendMessage(unknownCommandMessage);
++        }
+ 
+         return false;
+     }
+-- 
+2.25.1
+

--- a/patches/server/0193-Make-unknown-and-internal-command-messages-customisa.patch
+++ b/patches/server/0193-Make-unknown-and-internal-command-messages-customisa.patch
@@ -1,4 +1,4 @@
-From 33caddfe2015b8ad3ace67d7b9a78cd9d55bb0f7 Mon Sep 17 00:00:00 2001
+From 950e920f95c5399732e7106022222cc34ef7ffbd Mon Sep 17 00:00:00 2001
 From: VytskaLT <VytskaLT@protonmail.com>
 Date: Fri, 4 Dec 2020 13:56:51 +0200
 Subject: [PATCH] Make unknown and internal command messages customisable in
@@ -6,7 +6,7 @@ Subject: [PATCH] Make unknown and internal command messages customisable in
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 21747b92..cd984175 100644
+index 21747b92..5267250a 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1319,7 +1319,10 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
@@ -17,11 +17,11 @@ index 21747b92..cd984175 100644
 +        // SportPaper - make unknown command and internal error messages customisable
 +        PlayerCommandPreprocessEvent event = new PlayerCommandPreprocessEvent(player, s, new LazyPlayerSet(),
 +                org.spigotmc.SpigotConfig.unknownCommandMessage,
-+                org.bukkit.ChatColor.RED + "An internal error occurred while attempting to perform this command");
++                org.spigotmc.SpigotConfig.internalErrorMessage);
          this.server.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
-@@ -1328,12 +1331,16 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+@@ -1328,12 +1331,14 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
          }
  
          try {
@@ -33,15 +33,13 @@ index 21747b92..cd984175 100644
          } catch (org.bukkit.command.CommandException ex) {
 -            player.sendMessage(org.bukkit.ChatColor.RED + "An internal error occurred while attempting to perform this command");
 +            // SportPaper start
-+            if (event.getInternalErrorMessage() != null) {
-+                player.sendMessage(event.getInternalErrorMessage());
-+            }
++            player.sendMessage(event.getInternalErrorMessage());
 +            // SportPaper end
              java.util.logging.Logger.getLogger(PlayerConnection.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              SpigotTimings.playerCommandTimer.stopTiming(); // Spigot
              return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 613582cc..e4aab51d 100644
+index 613582cc..c90241cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -619,8 +619,14 @@ public final class CraftServer implements Server {
@@ -50,8 +48,7 @@ index 613582cc..e4aab51d 100644
  
 +    // SportPaper start
      @Override
--    public boolean dispatchCommand(CommandSender sender, String commandLine) {
-+    public boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandException {
+     public boolean dispatchCommand(CommandSender sender, String commandLine) {
 +        return dispatchCommand(sender, commandLine, org.spigotmc.SpigotConfig.unknownCommandMessage);
 +    }
 +    // SportPaper end
@@ -73,6 +70,26 @@ index 613582cc..e4aab51d 100644
  
          return false;
      }
+diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
+index ec995293..2b9358b2 100644
+--- a/src/main/java/org/spigotmc/SpigotConfig.java
++++ b/src/main/java/org/spigotmc/SpigotConfig.java
+@@ -84,6 +84,7 @@ public class SpigotConfig
+ 
+     public static String whitelistMessage;
+     public static String unknownCommandMessage;
++    public static String internalErrorMessage;
+     public static String serverFullMessage;
+     public static String outdatedClientMessage = "Outdated client! Please use {0}";
+     public static String outdatedServerMessage = "Outdated server! I\'m still on {0}";
+@@ -95,6 +96,7 @@ public class SpigotConfig
+     {
+         whitelistMessage = transform( getString( "messages.whitelist", "You are not whitelisted on this server!" ) );
+         unknownCommandMessage = transform( getString( "messages.unknown-command", "Unknown command. Type \"/help\" for help." ) );
++        internalErrorMessage = transform( getString( "messages.internal-error", "&cAn internal error occurred while attempting to perform this command" ) );
+         serverFullMessage = transform( getString( "messages.server-full", "The server is full!" ) );
+         outdatedClientMessage = transform( getString( "messages.outdated-client", outdatedClientMessage ) );
+         outdatedServerMessage = transform( getString( "messages.outdated-server", outdatedServerMessage ) );
 -- 
 2.25.1
 

--- a/sportpaper.yml
+++ b/sportpaper.yml
@@ -154,6 +154,7 @@ spigot:
     restart: Server is restarting!
     whitelist: You are not whitelisted on this server!
     unknown-command: Unknown command. Type "/help" for help.
+    internal-error: '&cAn internal error occurred while attempting to perform this command'
     server-full: The server is full!
     outdated-client: Outdated client! Please use {0}
     outdated-server: Outdated server! Server is on {0}


### PR DESCRIPTION
Makes the unknown command and internal error messages customisable in PlayerCommandPreprocessEvent. Useful for multi-language servers.