### PR TITLE
Several patches

### DIFF
--- a/patches/api/0102-Make-unknown-and-internal-command-messages-customisa.patch
+++ b/patches/api/0102-Make-unknown-and-internal-command-messages-customisa.patch
@@ -1,4 +1,4 @@
-From cf4e5aab74629c3d8e822c36d96190c87fc72f47 Mon Sep 17 00:00:00 2001
+From 52953c14cb276449dcdfdcf929a67035c94941f9 Mon Sep 17 00:00:00 2001
 From: VytskaLT <VytskaLT@protonmail.com>
 Date: Fri, 4 Dec 2020 13:56:52 +0200
 Subject: [PATCH] Make unknown and internal command messages customisable in

--- a/patches/api/0103-Make-PlayerEvent-async-constructor-public.patch
+++ b/patches/api/0103-Make-PlayerEvent-async-constructor-public.patch
@@ -1,0 +1,22 @@
+From 58a263a0d35c497944031b4286ac0fe3b1388f4d Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Sat, 17 Apr 2021 10:41:01 +0300
+Subject: [PATCH] Make PlayerEvent async constructor public
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerEvent.java b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+index fc183e74..cabca798 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+@@ -15,7 +15,7 @@ public abstract class PlayerEvent extends Event implements Physical {
+         player = who;
+     }
+ 
+-    PlayerEvent(final Player who, boolean async) {
++    public PlayerEvent(final Player who, boolean async) {
+         super(async);
+         player = who;
+ 
+-- 
+2.25.1
+

--- a/patches/server/0194-Update-MySQL-Connector.patch
+++ b/patches/server/0194-Update-MySQL-Connector.patch
@@ -1,4 +1,4 @@
-From f9913bb0c062147f10e221b9a40febf50d5b17c1 Mon Sep 17 00:00:00 2001
+From 8f44896ae94500d9533a5b8bf884e5e505fc475c Mon Sep 17 00:00:00 2001
 From: VytskaLT <VytskaLT@protonmail.com>
 Date: Tue, 15 Dec 2020 18:59:08 +0200
 Subject: [PATCH] Update MySQL Connector

--- a/patches/server/0195-Don-t-store-merchant-recipes-with-invalid-data.patch
+++ b/patches/server/0195-Don-t-store-merchant-recipes-with-invalid-data.patch
@@ -1,4 +1,4 @@
-From 0a3e547c29dc5daabdc868eff22d963252dffcda Mon Sep 17 00:00:00 2001
+From 708ee86d1712a62f3850136903ec5487ebeda5ac Mon Sep 17 00:00:00 2001
 From: Austin L Mayes <me@austinlm.me>
 Date: Mon, 21 Dec 2020 17:08:28 -0600
 Subject: [PATCH] Don't store merchant recipes with invalid data
@@ -19,5 +19,5 @@ index 3dd22559..3e4d5ed1 100644
          }
  
 -- 
-2.23.0
+2.25.1
 

--- a/patches/server/0196-Expose-client-disconnect-reason.patch
+++ b/patches/server/0196-Expose-client-disconnect-reason.patch
@@ -1,4 +1,4 @@
-From 1d40d7bd6f747f7723ed299fb39b2e3f71009155 Mon Sep 17 00:00:00 2001
+From e71bdd3cadca08aa2c3addefd95ff256a290443b Mon Sep 17 00:00:00 2001
 From: Austin L Mayes <me@austinlm.me>
 Date: Wed, 17 Feb 2021 16:37:59 -0600
 Subject: [PATCH] Expose client disconnect reason
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose client disconnect reason
 Signed-off-by: Austin L Mayes <me@austinlm.me>
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 21747b92..65424838 100644
+index 5267250a..5e903d40 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -722,7 +722,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
@@ -99,5 +99,5 @@ index d09f7453..cb6a3be0 100644
          entityplayer1.copyTo(entityplayer, flag);
          entityplayer1.d(entityplayer.getId());
 -- 
-2.23.0
+2.25.1
 

--- a/patches/server/0198-Fixed-chunk-memory-leak.patch
+++ b/patches/server/0198-Fixed-chunk-memory-leak.patch
@@ -1,0 +1,66 @@
+From 7d4d1d5eab983509cbff61d6635dd6cd69305326 Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Sat, 17 Apr 2021 10:27:53 +0300
+Subject: [PATCH] Fixed chunk memory leak
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+index 812686d5..28ca6aaf 100644
+--- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
++++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+@@ -32,7 +32,8 @@ public class ChunkProviderServer implements IChunkProvider {
+     public LongSet unloadQueue = new LongOpenHashSet(20); // SportPaper
+     public Chunk emptyChunk;
+     public IChunkProvider chunkProvider;
+-    private IChunkLoader chunkLoader;
++    // SportPaper - make chunkLoader public
++    public IChunkLoader chunkLoader;
+     public boolean forceChunkLoad = false; // CraftBukkit - true -> false
+     // Paper start
+     protected Chunk lastChunkByPos = null;
+diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
+index 6b244904..64d66602 100644
+--- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
++++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
+@@ -17,8 +17,9 @@ import org.apache.logging.log4j.Logger;
+ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
+ 
+     private static final Logger a = LogManager.getLogger();
+-    private Map<ChunkCoordIntPair, NBTTagCompound> b = new ConcurrentHashMap();
+-    private Set<ChunkCoordIntPair> c = Collections.newSetFromMap(new ConcurrentHashMap());
++    // SportPaper - make b and c public
++    public Map<ChunkCoordIntPair, NBTTagCompound> b = new ConcurrentHashMap();
++    public Set<ChunkCoordIntPair> c = Collections.newSetFromMap(new ConcurrentHashMap());
+     private final File d;
+     private boolean e = false;
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index c90241cd..f5b78d0a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -919,6 +919,22 @@ public final class CraftServer implements Server {
+             } catch (ExceptionWorldConflict ex) {
+                 getLogger().log(Level.SEVERE, null, ex);
+             }
++        } else { // SportPaper - fix chunk memory leak
++            ChunkProviderServer chunkProviderServer = handle.chunkProviderServer;
++            ChunkRegionLoader regionLoader = (ChunkRegionLoader) chunkProviderServer.chunkLoader;
++
++            regionLoader.b.clear();
++            regionLoader.c.clear();
++
++            try {
++                FileIOThread.a().b();
++            } catch (InterruptedException ex) {
++                Thread.currentThread().interrupt();
++            }
++
++            chunkProviderServer.chunkLoader = null;
++            chunkProviderServer.chunkProvider = null;
++            chunkProviderServer.chunks.clear();
+         }
+ 
+         worlds.remove(world.getName().toLowerCase());
+-- 
+2.25.1
+

--- a/patches/server/0199-Limit-CraftChatMessage-iterations.patch
+++ b/patches/server/0199-Limit-CraftChatMessage-iterations.patch
@@ -1,0 +1,29 @@
+From 2dce85dbd1b9b461a8fbcfef8ecb1feefe24964f Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Sat, 17 Apr 2021 10:28:37 +0300
+Subject: [PATCH] Limit CraftChatMessage iterations
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
+index 38ef8216..a68d9e38 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
+@@ -143,8 +143,14 @@ public final class CraftChatMessage {
+     public static String fromComponent(IChatBaseComponent component, EnumChatFormat defaultColor) {
+         if (component == null) return "";
+         StringBuilder out = new StringBuilder();
+-        
++        // SportPaper - limit iterations to 2
++        byte iterations = 0;
++
+         for (IChatBaseComponent c : (Iterable<IChatBaseComponent>) component) {
++            if (++iterations > 2) {
++                break;
++            }
++
+             ChatModifier modi = c.getChatModifier();
+             out.append(modi.getColor() == null ? defaultColor : modi.getColor());
+             if (modi.isBold()) {
+-- 
+2.25.1
+

--- a/patches/server/0200-Don-t-use-force-unload-for-keep-spawn-setting-change.patch
+++ b/patches/server/0200-Don-t-use-force-unload-for-keep-spawn-setting-change.patch
@@ -1,0 +1,22 @@
+From 4241affadf0b5712c38963756d9eb86c65bbe35d Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Sat, 17 Apr 2021 10:39:04 +0300
+Subject: [PATCH] Don't use force unload for keep spawn setting change
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index b2eaf0c7..a3fec8d3 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -235,7 +235,7 @@ public class CraftWorld implements World {
+     }
+ 
+     public boolean unloadChunk(int x, int z) {
+-        return unloadChunk(x, z, true);
++        return unloadChunkRequest(x, z); // SportPaper
+     }
+ 
+     public boolean unloadChunk(int x, int z, boolean save) {
+-- 
+2.25.1
+

--- a/patches/server/0201-Cache-block-break-animation-packet.patch
+++ b/patches/server/0201-Cache-block-break-animation-packet.patch
@@ -1,0 +1,33 @@
+From 88b24a411ba183287a92d16136b4a859b83529d0 Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Sat, 17 Apr 2021 10:43:08 +0300
+Subject: [PATCH] Cache block break animation packet
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldManager.java b/src/main/java/net/minecraft/server/WorldManager.java
+index 55a2112d..1acae40d 100644
+--- a/src/main/java/net/minecraft/server/WorldManager.java
++++ b/src/main/java/net/minecraft/server/WorldManager.java
+@@ -61,6 +61,7 @@ public class WorldManager implements IWorldAccess {
+         if (entity instanceof EntityHuman) entityhuman = (EntityHuman) entity;
+         // CraftBukkit end
+ 
++        PacketPlayOutBlockBreakAnimation packet = null; // SportPaper - cache packet
+         while (iterator.hasNext()) {
+             EntityPlayer entityplayer = (EntityPlayer) iterator.next();
+ 
+@@ -76,7 +77,10 @@ public class WorldManager implements IWorldAccess {
+                 // CraftBukkit end
+ 
+                 if (d0 * d0 + d1 * d1 + d2 * d2 < 1024.0D) {
+-                    entityplayer.playerConnection.sendPacket(new PacketPlayOutBlockBreakAnimation(i, blockposition, j));
++                    // SportPaper start
++                    if (packet == null) packet = new PacketPlayOutBlockBreakAnimation(i, blockposition, j);
++                    entityplayer.playerConnection.sendPacket(packet);
++                    // SportPaper end
+                 }
+             }
+         }
+-- 
+2.25.1
+

--- a/patches/server/0202-Fix-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0202-Fix-EntityKnockbackByEntityEvent.patch
@@ -1,4 +1,4 @@
-From 86704ba4ed5bb1491ab1ec716b985a1ba4195f6f Mon Sep 17 00:00:00 2001
+From 1e114738ed942f22f95f51640cc33700e129de11 Mon Sep 17 00:00:00 2001
 From: VytskaLT <VytskaLT@protonmail.com>
 Date: Sat, 17 Apr 2021 19:20:22 +0300
 Subject: [PATCH] Fix EntityKnockbackByEntityEvent
@@ -17,7 +17,7 @@ index bc024176..237d9df3 100644
  
      public static DamageSource mobAttack(EntityLiving entityliving) {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index ede4e3e9..d97602c3 100644
+index ede4e3e9..f311373f 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -841,7 +841,7 @@ public abstract class EntityLiving extends Entity {
@@ -25,7 +25,7 @@ index ede4e3e9..d97602c3 100644
  
                          this.aw = (float) (MathHelper.b(d1, d0) * 180.0D / 3.1415927410125732D - (double) this.yaw);
 -                        this.a(entity, f, d0, d1);
-+                        damagesource.knockbackEventCalled = this.a(entity, f, d0, d1);
++                        damagesource.knockbackEventCalled = this.a(entity, f, d0, d1); // SportPaper
                      } else {
                          this.aw = (float) ((int) (Math.random() * 2.0D) * 180);
                      }
@@ -58,21 +58,23 @@ index ede4e3e9..d97602c3 100644
  
      protected String bo() {
 diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
-index b7d410ee..a7d1cc14 100644
+index b7d410ee..da8cc0f7 100644
 --- a/src/main/java/net/minecraft/server/Explosion.java
 +++ b/src/main/java/net/minecraft/server/Explosion.java
-@@ -135,7 +135,9 @@ public class Explosion {
+@@ -135,7 +135,11 @@ public class Explosion {
                          // entity.damageEntity(DamageSource.explosion(this), (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)));+                        // CraftBukkit start
                          CraftEventFactory.entityDamage = source;
                          entity.forceExplosionKnockback = false;
 -                        boolean wasDamaged = entity.damageEntity(DamageSource.explosion(this), (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)));
-+                        DamageSource damageSource = DamageSource.explosion(this); // SportPaper
-+                        float f = (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)); // SportPaper
++                        // SportPaper start
++                        DamageSource damageSource = DamageSource.explosion(this);
++                        float f = (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D));
 +                        boolean wasDamaged = entity.damageEntity(damageSource, f);
++                        // SportPaper end
                          CraftEventFactory.entityDamage = null;
                          if (!wasDamaged && !(entity instanceof EntityTNTPrimed || entity instanceof EntityFallingBlock) && !entity.forceExplosionKnockback) {
                              continue;
-@@ -150,11 +152,22 @@ public class Explosion {
+@@ -150,11 +154,22 @@ public class Explosion {
                          entity.motZ += d10 * d14;
                          */
                          // This impulse method sets the dirty flag, so clients will get an immediate velocity update

--- a/patches/server/0202-Fix-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0202-Fix-EntityKnockbackByEntityEvent.patch
@@ -1,0 +1,102 @@
+From 86704ba4ed5bb1491ab1ec716b985a1ba4195f6f Mon Sep 17 00:00:00 2001
+From: VytskaLT <VytskaLT@protonmail.com>
+Date: Sat, 17 Apr 2021 19:20:22 +0300
+Subject: [PATCH] Fix EntityKnockbackByEntityEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/DamageSource.java b/src/main/java/net/minecraft/server/DamageSource.java
+index bc024176..237d9df3 100644
+--- a/src/main/java/net/minecraft/server/DamageSource.java
++++ b/src/main/java/net/minecraft/server/DamageSource.java
+@@ -26,6 +26,7 @@ public class DamageSource {
+     private boolean w;
+     private boolean x;
+     private boolean y;
++    public boolean knockbackEventCalled; // SportPaper
+     public String translationIndex;
+ 
+     public static DamageSource mobAttack(EntityLiving entityliving) {
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index ede4e3e9..d97602c3 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -841,7 +841,7 @@ public abstract class EntityLiving extends Entity {
+                         }
+ 
+                         this.aw = (float) (MathHelper.b(d1, d0) * 180.0D / 3.1415927410125732D - (double) this.yaw);
+-                        this.a(entity, f, d0, d1);
++                        damagesource.knockbackEventCalled = this.a(entity, f, d0, d1);
+                     } else {
+                         this.aw = (float) ((int) (Math.random() * 2.0D) * 180);
+                     }
+@@ -932,7 +932,7 @@ public abstract class EntityLiving extends Entity {
+ 
+     protected void dropEquipment(boolean flag, int i) {}
+ 
+-    public void a(Entity entity, float f, double d0, double d1) {
++    public boolean a(Entity entity, float f, double d0, double d1) { // SportPaper - void -> boolean
+         if (this.random.nextDouble() >= this.getAttributeInstance(GenericAttributes.c).getValue()) {
+             this.ai = true;
+ 
+@@ -969,14 +969,16 @@ public abstract class EntityLiving extends Entity {
+             this.motX = oldMotX;
+             this.motY = oldMotY;
+             this.motZ = oldMotZ;
+-            if (entity == null || new EntityKnockbackByEntityEvent((LivingEntity) getBukkitEntity(), entity.getBukkitEntity(), f, delta).callEvent()) {
++            org.bukkit.entity.Entity bukkitEntity = getBukkitEntity(); // SportPaper
++            if (entity == null || new EntityKnockbackByEntityEvent((LivingEntity) bukkitEntity, ((org.bukkit.event.entity.EntityDamageByEntityEvent) bukkitEntity.getLastDamageCause()).getDamager(), f, delta).callEvent()) { // SportPaper - fix EntityKnockbackByEntityEvent
+                 this.motX += delta.getX();
+                 this.motY += delta.getY();
+                 this.motZ += delta.getZ();
+             }
+             // Paper end
+-
++            return true; // SportPaper
+         }
++        return false; // SportPaper
+     }
+ 
+     protected String bo() {
+diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
+index b7d410ee..a7d1cc14 100644
+--- a/src/main/java/net/minecraft/server/Explosion.java
++++ b/src/main/java/net/minecraft/server/Explosion.java
+@@ -135,7 +135,9 @@ public class Explosion {
+                         // entity.damageEntity(DamageSource.explosion(this), (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)));+                        // CraftBukkit start
+                         CraftEventFactory.entityDamage = source;
+                         entity.forceExplosionKnockback = false;
+-                        boolean wasDamaged = entity.damageEntity(DamageSource.explosion(this), (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)));
++                        DamageSource damageSource = DamageSource.explosion(this); // SportPaper
++                        float f = (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D)); // SportPaper
++                        boolean wasDamaged = entity.damageEntity(damageSource, f);
+                         CraftEventFactory.entityDamage = null;
+                         if (!wasDamaged && !(entity instanceof EntityTNTPrimed || entity instanceof EntityFallingBlock) && !entity.forceExplosionKnockback) {
+                             continue;
+@@ -150,11 +152,22 @@ public class Explosion {
+                         entity.motZ += d10 * d14;
+                         */
+                         // This impulse method sets the dirty flag, so clients will get an immediate velocity update
+-                        entity.g(d8 * d14, d9 * d14, d10 * d14);
++                        // SportPaper start - Call EntityKnockbackByEntityEvent
++                        org.bukkit.util.Vector vector = new org.bukkit.util.Vector(d8 * d14, d9 * d14, d10 * d14);
++                        if (!damageSource.knockbackEventCalled && entity instanceof EntityLiving && !new org.github.paperspigot.event.entity.EntityKnockbackByEntityEvent((org.bukkit.entity.LivingEntity) entity.getBukkitEntity(), source.getBukkitEntity(), f, vector).callEvent()) {
++                            vector.setX(0);
++                            vector.setY(0);
++                            vector.setZ(0);
++                        }
++                        double x = vector.getX();
++                        double y = vector.getY();
++                        double z = vector.getZ();
++                        entity.g(x, y, z);
++                        // SportPaper end
+                         // PaperSpigot end
+ 
+                         if (entity instanceof EntityHuman && !((EntityHuman) entity).abilities.isInvulnerable && !world.paperSpigotConfig.disableExplosionKnockback) { // PaperSpigot
+-                            this.k.put((EntityHuman) entity, new Vec3D(d8 * d13, d9 * d13, d10 * d13));
++                            this.k.put((EntityHuman) entity, new Vec3D(x, y, z)); // SportPaper
+                         }
+                     }
+                 }
+-- 
+2.25.1
+


### PR DESCRIPTION
This PR has these patches:
- Chunk memory leak fix (closes #40, patch provided by @LewUwU)
- CraftChatMessage-iteration (closes #40, patch provided by @LewUwU)
- Don't use force unload for keep spawn setting change (closes #13, patch provided by @LewUwU)
- Caching block break animation packet (before it would create the same packet for each player)
- Fix EntityKnockbackByEntityEvent (closes #50). Now it's called for explosions too and the "hitBy" variable is set to the actual entity that did the knockback
- Make PlayerEvent async constructor public. For some reason it was package-private.