### PR TITLE
Always delete UserCache on error

### DIFF
--- a/patches/server/0203-Always-delete-UserCache-on-error.patch
+++ b/patches/server/0203-Always-delete-UserCache-on-error.patch
@@ -1,0 +1,31 @@
+From 4c0610aebcd9fbc0d15d781709b52607c86af87f Mon Sep 17 00:00:00 2001
+From: linsaftw <linsaftw@users.noreply.github.com>
+Date: Tue, 27 Apr 2021 10:26:42 -0300
+Subject: [PATCH] Always delete UserCache on error
+
+
+diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
+index c3bdb881..700c6069 100644
+--- a/src/main/java/net/minecraft/server/UserCache.java
++++ b/src/main/java/net/minecraft/server/UserCache.java
+@@ -199,15 +199,10 @@ public class UserCache {
+                     this.a(usercache_usercacheentry.a(), usercache_usercacheentry.b());
+                 }
+             }
+-        } catch (FileNotFoundException filenotfoundexception) {
+-            ;
+-        // Spigot Start
+-        } catch (com.google.gson.JsonSyntaxException ex) {
++        } catch (Exception ex) {
++            // SportPaper - Catch all UserCache exceptions in one and always delete
+             JsonList.a.warn( "Usercache.json is corrupted or has bad formatting. Deleting it to prevent further issues." );
+             this.g.delete();
+-        // Spigot End
+-        } catch (JsonParseException jsonparseexception) {
+-            ;
+         } finally {
+             IOUtils.closeQuietly(bufferedreader);
+         }
+-- 
+2.31.1
+


### PR DESCRIPTION
Sometimes the server can't start because of UserCache corruption. This fixes it.