### PR TITLE
Add upstream CraftBukkit 1.8.8 log4j patches

### DIFF
--- a/patches/server/0206-Add-API-for-custom-format-loaders.patch
+++ b/patches/server/0206-Add-API-for-custom-format-loaders.patch
@@ -1,4 +1,4 @@
-From cb6ee67011963c3de485743cb37ae4d93ab5b2fe Mon Sep 17 00:00:00 2001
+From 23260df35df06d1fcecfbb13454e3c1961afc264 Mon Sep 17 00:00:00 2001
 From: William Jeffcock <jeffcockw@gmail.com>
 Date: Thu, 23 Sep 2021 01:11:33 +0100
 Subject: [PATCH] Add API for custom format loaders
@@ -145,7 +145,7 @@ index 590095e4..363b4d4d 100644
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/world/AnvilFormatLoader.java b/src/main/java/org/bukkit/craftbukkit/world/AnvilFormatLoader.java
 new file mode 100644
-index 00000000..8050f252
+index 00000000..622841b0
 --- /dev/null
 +++ b/src/main/java/org/bukkit/craftbukkit/world/AnvilFormatLoader.java
 @@ -0,0 +1,109 @@
@@ -261,7 +261,7 @@ index 00000000..8050f252
 \ No newline at end of file
 diff --git a/src/main/java/org/bukkit/craftbukkit/world/CraftFormatManager.java b/src/main/java/org/bukkit/craftbukkit/world/CraftFormatManager.java
 new file mode 100644
-index 00000000..212063c0
+index 00000000..7b0de027
 --- /dev/null
 +++ b/src/main/java/org/bukkit/craftbukkit/world/CraftFormatManager.java
 @@ -0,0 +1,27 @@
@@ -294,7 +294,7 @@ index 00000000..212063c0
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/world/IWorldFormat.java b/src/main/java/org/bukkit/craftbukkit/world/IWorldFormat.java
 new file mode 100644
-index 00000000..01c8af4f
+index 00000000..8466cd0d
 --- /dev/null
 +++ b/src/main/java/org/bukkit/craftbukkit/world/IWorldFormat.java
 @@ -0,0 +1,18 @@
@@ -318,7 +318,7 @@ index 00000000..01c8af4f
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/world/IWorldFormatProvider.java b/src/main/java/org/bukkit/craftbukkit/world/IWorldFormatProvider.java
 new file mode 100644
-index 00000000..8dbd5826
+index 00000000..5bac0f05
 --- /dev/null
 +++ b/src/main/java/org/bukkit/craftbukkit/world/IWorldFormatProvider.java
 @@ -0,0 +1,11 @@
@@ -334,5 +334,5 @@ index 00000000..8dbd5826
 +
 +}
 -- 
-2.17.1
+2.34.1
 

--- a/patches/server/0208-Disable-log4j-message-formatting.patch
+++ b/patches/server/0208-Disable-log4j-message-formatting.patch
@@ -1,0 +1,26 @@
+From 9e1fc71688bd80e8c75f5f719e86f4bfe5079139 Mon Sep 17 00:00:00 2001
+From: md_5 <git@md-5.net>
+Date: Fri, 10 Dec 2021 07:53:20 +1100
+Subject: [PATCH] Disable log4j message formatting
+
+
+diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
+index f37d1c2d..0452fbc0 100644
+--- a/src/main/resources/log4j2.xml
++++ b/src/main/resources/log4j2.xml
+@@ -3,10 +3,10 @@
+     <Appenders>
+         <Console name="WINDOWS_COMPAT" target="SYSTEM_OUT"></Console>
+         <Queue name="TerminalConsole">
+-            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n" />
++            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg{nolookups}%n" />
+         </Queue>
+         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
++            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n" />
+             <Policies>
+                 <TimeBasedTriggeringPolicy />
+                 <OnStartupTriggeringPolicy />
+-- 
+2.34.1
+

--- a/patches/server/0209-Upgrade-log4j-version.patch
+++ b/patches/server/0209-Upgrade-log4j-version.patch
@@ -1,0 +1,277 @@
+From 3df98e5dc52f42fb3205872b240a8744f3d1d1ff Mon Sep 17 00:00:00 2001
+From: md_5 <git@md-5.net>
+Date: Fri, 10 Dec 2021 12:22:45 +1100
+Subject: [PATCH] Upgrade log4j version
+
+
+diff --git a/pom.xml b/pom.xml
+index 4c3a52a8..2dee42e5 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -44,6 +44,12 @@
+             <type>jar</type>
+             <scope>compile</scope>
+         </dependency>
++        <dependency>
++            <groupId>org.apache.logging.log4j</groupId>
++            <artifactId>log4j-core</artifactId>
++            <version>2.8.1</version>
++            <scope>compile</scope>
++        </dependency>
+         <dependency>
+             <groupId>org.spigotmc</groupId>
+             <artifactId>minecraft-server</artifactId>
+diff --git a/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java b/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+deleted file mode 100644
+index 341eaa33..00000000
+--- a/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
++++ /dev/null
+@@ -1,245 +0,0 @@
+-/*
+- * Licensed to the Apache Software Foundation (ASF) under one or more
+- * contributor license agreements. See the NOTICE file distributed with
+- * this work for additional information regarding copyright ownership.
+- * The ASF licenses this file to You under the Apache license, Version 2.0
+- * (the "License"); you may not use this file except in compliance with
+- * the License. You may obtain a copy of the License at
+- *
+- *      http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the license for the specific language governing permissions and
+- * limitations under the license.
+- */
+-package org.apache.logging.log4j.core.appender;
+-
+-import java.io.IOException;
+-import java.io.OutputStream;
+-import java.io.PrintStream;
+-import java.io.Serializable;
+-import java.io.UnsupportedEncodingException;
+-import java.lang.reflect.Constructor;
+-import java.nio.charset.Charset;
+-
+-import org.apache.logging.log4j.core.Filter;
+-import org.apache.logging.log4j.core.Layout;
+-import org.apache.logging.log4j.core.config.plugins.Plugin;
+-import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+-import org.apache.logging.log4j.core.config.plugins.PluginElement;
+-import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+-import org.apache.logging.log4j.core.helpers.Booleans;
+-import org.apache.logging.log4j.core.helpers.Loader;
+-import org.apache.logging.log4j.core.layout.PatternLayout;
+-import org.apache.logging.log4j.util.PropertiesUtil;
+-
+-/**
+- * ConsoleAppender appends log events to <code>System.out</code> or
+- * <code>System.err</code> using a layout specified by the user. The
+- * default target is <code>System.out</code>.
+- * @doubt accessing System.out or .err as a byte stream instead of a writer
+- *    bypasses the JVM's knowledge of the proper encoding. (RG) Encoding
+- * is handled within the Layout. Typically, a Layout will generate a String
+- * and then call getBytes which may use a configured encoding or the system
+- * default. OTOH, a Writer cannot print byte streams.
+- */
+-@Plugin(name = "Console", category = "Core", elementType = "appender", printObject = true)
+-public final class ConsoleAppender extends AbstractOutputStreamAppender {
+-
+-    private static final String JANSI_CLASS = "org.fusesource.jansi.WindowsAnsiOutputStream";
+-    private static ConsoleManagerFactory factory = new ConsoleManagerFactory();
+-
+-    /**
+-     * Enumeration of console destinations.
+-     */
+-    public enum Target {
+-        /** Standard output. */
+-        SYSTEM_OUT,
+-        /** Standard error output. */
+-        SYSTEM_ERR
+-    }
+-
+-    private ConsoleAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
+-                            final OutputStreamManager manager,
+-                            final boolean ignoreExceptions) {
+-        super(name, layout, filter, ignoreExceptions, true, manager);
+-    }
+-
+-    /**
+-     * Create a Console Appender.
+-     * @param layout The layout to use (required).
+-     * @param filter The Filter or null.
+-     * @param t The target ("SYSTEM_OUT" or "SYSTEM_ERR"). The default is "SYSTEM_OUT".
+-     * @param follow If true will follow changes to the underlying output stream.
+-     * @param name The name of the Appender (required).
+-     * @param ignore If {@code "true"} (default) exceptions encountered when appending events are logged; otherwise
+-     *               they are propagated to the caller.
+-     * @return The ConsoleAppender.
+-     */
+-    @PluginFactory
+-    public static ConsoleAppender createAppender(
+-            @PluginElement("Layout") Layout<? extends Serializable> layout,
+-            @PluginElement("Filters") final Filter filter,
+-            @PluginAttribute("target") final String t,
+-            @PluginAttribute("name") final String name,
+-            @PluginAttribute("follow") final String follow,
+-            @PluginAttribute("ignoreExceptions") final String ignore) {
+-        if (name == null) {
+-            LOGGER.error("No name provided for ConsoleAppender");
+-            return null;
+-        }
+-        if (layout == null) {
+-            layout = PatternLayout.createLayout(null, null, null, null, null);
+-        }
+-        final boolean isFollow = Boolean.parseBoolean(follow);
+-        final boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
+-        final Target target = t == null ? Target.SYSTEM_OUT : Target.valueOf(t);
+-        return new ConsoleAppender(name, layout, filter, getManager(isFollow, target, layout), ignoreExceptions);
+-    }
+-
+-    private static OutputStreamManager getManager(final boolean follow, final Target target, final Layout<? extends Serializable> layout) {
+-        final String type = target.name();
+-        final OutputStream os = getOutputStream(follow, target);
+-        return OutputStreamManager.getManager(target.name() + "." + follow, new FactoryData(os, type, layout), factory);
+-    }
+-
+-    private static OutputStream getOutputStream(final boolean follow, final Target target) {
+-        final String enc = Charset.defaultCharset().name();
+-        PrintStream printStream = null;
+-        try {
+-            printStream = target == Target.SYSTEM_OUT ?
+-                    follow ? new PrintStream(new SystemOutStream(), true, enc) : System.out :
+-                    follow ? new PrintStream(new SystemErrStream(), true, enc) : System.err;
+-        } catch (final UnsupportedEncodingException ex) { // should never happen
+-            throw new IllegalStateException("Unsupported default encoding " + enc, ex);
+-        }
+-        final PropertiesUtil propsUtil = PropertiesUtil.getProperties();
+-        if (!propsUtil.getStringProperty("os.name").startsWith("Windows") ||
+-                propsUtil.getBooleanProperty("log4j.skipJansi")) {
+-            return printStream;
+-        }
+-        try {
+-            final ClassLoader loader = Loader.getClassLoader();
+-            // We type the parameter as a wildcard to avoid a hard reference to Jansi.
+-            final Class<?> clazz = loader.loadClass(JANSI_CLASS);
+-            final Constructor<?> constructor = clazz.getConstructor(OutputStream.class);
+-            return (OutputStream) constructor.newInstance(printStream);
+-        } catch (final ClassNotFoundException cnfe) {
+-            LOGGER.debug("Jansi is not installed, cannot find {}", JANSI_CLASS);
+-        } catch (final NoSuchMethodException nsme) {
+-            LOGGER.warn("{} is missing the proper constructor", JANSI_CLASS);
+-        } catch (final Throwable ex) { // CraftBukkit - Exception -> Throwable
+-            LOGGER.warn("Unable to instantiate {}", JANSI_CLASS);
+-        }
+-        return printStream;
+-    }
+-
+-    /**
+-     * An implementation of OutputStream that redirects to the current System.err.
+-     */
+-    private static class SystemErrStream extends OutputStream {
+-        public SystemErrStream() {
+-        }
+-
+-        @Override
+-        public void close() {
+-            // do not close sys err!
+-        }
+-
+-        @Override
+-        public void flush() {
+-            System.err.flush();
+-        }
+-
+-        @Override
+-        public void write(final byte[] b) throws IOException {
+-            System.err.write(b);
+-        }
+-
+-        @Override
+-        public void write(final byte[] b, final int off, final int len)
+-                throws IOException {
+-            System.err.write(b, off, len);
+-        }
+-
+-        @Override
+-        public void write(final int b) {
+-            System.err.write(b);
+-        }
+-    }
+-
+-    /**
+-     * An implementation of OutputStream that redirects to the current System.out.
+-     */
+-    private static class SystemOutStream extends OutputStream {
+-        public SystemOutStream() {
+-        }
+-
+-        @Override
+-        public void close() {
+-            // do not close sys out!
+-        }
+-
+-        @Override
+-        public void flush() {
+-            System.out.flush();
+-        }
+-
+-        @Override
+-        public void write(final byte[] b) throws IOException {
+-            System.out.write(b);
+-        }
+-
+-        @Override
+-        public void write(final byte[] b, final int off, final int len)
+-                throws IOException {
+-            System.out.write(b, off, len);
+-        }
+-
+-        @Override
+-        public void write(final int b) throws IOException {
+-            System.out.write(b);
+-        }
+-    }
+-
+-    /**
+-     * Data to pass to factory method.
+-     */
+-    private static class FactoryData {
+-        private final OutputStream os;
+-        private final String type;
+-        private final Layout<? extends Serializable> layout;
+-
+-        /**
+-         * Constructor.
+-         * @param os The OutputStream.
+-         * @param type The name of the target.
+-         * @param layout A Serializable layout
+-         */
+-        public FactoryData(final OutputStream os, final String type, final Layout<? extends Serializable> layout) {
+-            this.os = os;
+-            this.type = type;
+-            this.layout = layout;
+-        }
+-    }
+-
+-    /**
+-     * Factory to create the Appender.
+-     */
+-    private static class ConsoleManagerFactory implements ManagerFactory<OutputStreamManager, FactoryData> {
+-
+-        /**
+-         * Create an OutputStreamManager.
+-         * @param name The name of the entity to manage.
+-         * @param data The data required to create the entity.
+-         * @return The OutputStreamManager
+-         */
+-        @Override
+-        public OutputStreamManager createManager(final String name, final FactoryData data) {
+-            return new OutputStreamManager(data.os, data.type, data.layout);
+-        }
+-    }
+-
+-}
+-- 
+2.34.1
+


### PR DESCRIPTION
CraftBukkit's 1.8.8 branch has been updated with these two patches following the discovery/announcement of the log4j exploit. Ideally, upstream Paper 1.8.8 would have the CraftBukkit submodule updated to the latest commit and then we could update the Paper submodule here, but perhaps this is preferred since it is quicker. 