### PR TITLE
Apply explosion knockback to projectiles

### DIFF
--- a/patches/server/0210-Apply-explosion-knockback-to-projectiles.patch
+++ b/patches/server/0210-Apply-explosion-knockback-to-projectiles.patch
@@ -1,0 +1,27 @@
+From 6dd05da521c5e6c6bf38ad396cc6352265ff5eef Mon Sep 17 00:00:00 2001
+From: woofdoggo <woofwoofdoggo@protonmail.com>
+Date: Wed, 11 May 2022 16:49:54 -0400
+Subject: [PATCH] Apply explosion knockback to projectiles
+
+
+diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
+index 0d6ccbf7..e90b1c23 100644
+--- a/src/main/java/net/minecraft/server/Explosion.java
++++ b/src/main/java/net/minecraft/server/Explosion.java
+@@ -139,11 +139,11 @@ public class Explosion {
+                         DamageSource damageSource = DamageSource.explosion(this);
+                         float f = (float) ((int) ((d13 * d13 + d13) / 2.0D * 8.0D * (double) f3 + 1.0D));
+                         boolean wasDamaged = entity.damageEntity(damageSource, f);
+-                        // SportPaper end
+                         CraftEventFactory.entityDamage = null;
+-                        if (!wasDamaged && !(entity instanceof EntityTNTPrimed || entity instanceof EntityFallingBlock) && !entity.forceExplosionKnockback) {
++                        if (!wasDamaged && !(entity instanceof IProjectile || entity instanceof EntityTNTPrimed || entity instanceof EntityFallingBlock) && !entity.forceExplosionKnockback) {
+                             continue;
+                         }
++                        // SportPaper end
+                         // CraftBukkit end
+                         double d14 = entity instanceof EntityHuman && world.paperSpigotConfig.disableExplosionKnockback ? 0 : EnchantmentProtection.a(entity, d13); // PaperSpigot
+ 
+-- 
+2.36.1
+


### PR DESCRIPTION
Explosion knockback currently does not apply to projectiles. This PR makes projectiles (arrows, snowballs, etc) take knockback from exploding TNT (see [upstream issue](https://hub.spigotmc.org/jira/browse/SPIGOT-6777), [fix](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/cc86ab1886c9d2d50495711288ffad33a0c7e554#nms-patches/net/minecraft/world/level/Explosion.patch)).

Feel free to let me know if anything is wrong with this or needs adjusting. I've never done any server modding before and am not sure if this has any subtle adverse effects. I've also encountered an issue with the paperclip target ([related?](https://github.com/Electroid/SportPaper/issues/80)) but the normal build seems to work fine.

https://user-images.githubusercontent.com/46545045/167948979-51ee6c87-82c4-494e-844b-7ecc4c71897d.mp4