### PR TITLE
Update to Netty 4.1.x

### DIFF
--- a/patches/server/0211-Update-to-Netty-4.1.x.patch
+++ b/patches/server/0211-Update-to-Netty-4.1.x.patch
@@ -1,0 +1,320 @@
+From 42f916afdb36bd909528c561005c98395a503a58 Mon Sep 17 00:00:00 2001
+From: hpfxd <me@hpfxd.com>
+Date: Wed, 27 Oct 2021 06:29:44 -0400
+Subject: [PATCH] Update to Netty 4.1.x
+
+
+diff --git a/pom.xml b/pom.xml
+index 2dee42e5..e6ea4704 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -27,6 +27,11 @@
+     </parent>
+ 
+     <dependencies>
++        <dependency>
++            <groupId>io.netty</groupId>
++            <artifactId>netty-all</artifactId>
++            <version>4.1.82.Final</version>
++        </dependency>
+         <dependency>
+             <groupId>it.unimi.dsi</groupId>
+             <artifactId>fastutil</artifactId>
+diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+index e2eb3054..9a075fef 100644
+--- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
++++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+@@ -20,6 +20,10 @@ import java.nio.channels.GatheringByteChannel;
+ import java.nio.channels.ScatteringByteChannel;
+ import java.nio.charset.Charset;
+ import java.util.UUID;
++// SportPaper start
++import io.netty.util.ByteProcessor;
++import java.nio.channels.FileChannel;
++// SportPaper end
+ 
+ import org.bukkit.craftbukkit.inventory.CraftItemStack; // CraftBukkit
+ 
+@@ -221,7 +225,11 @@ public class PacketDataSerializer extends ByteBuf {
+         } else if (j < 0) {
+             throw new DecoderException("The received encoded string buffer length is less than zero! Weird string!");
+         } else {
+-            String s = new String(this.readBytes(j).array(), Charsets.UTF_8);
++            // SportPaper start - Switch from readBytes().array() to readBytes(byte[]) as we could be dealing with a DirectByteBuf
++            byte[] b = new byte[j];
++            this.readBytes(b);
++            String s = new String(b, Charsets.UTF_8);
++            // SportPaper end
+ 
+             if (s.length() > i) {
+                 throw new DecoderException("The received string length is longer than maximum allowed (" + j + " > " + i + ")");
+@@ -822,4 +830,266 @@ public class PacketDataSerializer extends ByteBuf {
+     public boolean release(int i) {
+         return this.a.release(i);
+     }
++
++    // SportPaper start - Delegate new Netty 4.1 methods.
++    @Override
++    public boolean isReadOnly() {
++        return a.isReadOnly();
++    }
++
++    @Override
++    public ByteBuf asReadOnly() {
++        return a.asReadOnly();
++    }
++
++    @Override
++    public int maxFastWritableBytes() {
++        return a.maxFastWritableBytes();
++    }
++
++    @Override
++    public short getShortLE(int index) {
++        return a.getShortLE(index);
++    }
++
++    @Override
++    public int getUnsignedShortLE(int index) {
++        return a.getUnsignedShortLE(index);
++    }
++
++    @Override
++    public int getMediumLE(int index) {
++        return a.getMediumLE(index);
++    }
++
++    @Override
++    public int getUnsignedMediumLE(int index) {
++        return a.getUnsignedMediumLE(index);
++    }
++
++    @Override
++    public int getIntLE(int index) {
++        return a.getIntLE(index);
++    }
++
++    @Override
++    public long getUnsignedIntLE(int index) {
++        return a.getUnsignedIntLE(index);
++    }
++
++    @Override
++    public long getLongLE(int index) {
++        return a.getLongLE(index);
++    }
++
++    @Override
++    public float getFloatLE(int index) {
++        return a.getFloatLE(index);
++    }
++
++    @Override
++    public double getDoubleLE(int index) {
++        return a.getDoubleLE(index);
++    }
++
++    @Override
++    public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
++        return a.getBytes(index, out, position, length);
++    }
++
++    @Override
++    public CharSequence getCharSequence(int index, int length, Charset charset) {
++        return a.getCharSequence(index, length, charset);
++    }
++
++    @Override
++    public ByteBuf setShortLE(int index, int value) {
++        return a.setShortLE(index, value);
++    }
++
++    @Override
++    public ByteBuf setMediumLE(int index, int value) {
++        return a.setMediumLE(index, value);
++    }
++
++    @Override
++    public ByteBuf setIntLE(int index, int value) {
++        return a.setIntLE(index, value);
++    }
++
++    @Override
++    public ByteBuf setLongLE(int index, long value) {
++        return a.setLongLE(index, value);
++    }
++
++    @Override
++    public ByteBuf setFloatLE(int index, float value) {
++        return a.setFloatLE(index, value);
++    }
++
++    @Override
++    public ByteBuf setDoubleLE(int index, double value) {
++        return a.setDoubleLE(index, value);
++    }
++
++    @Override
++    public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
++        return a.setBytes(index, in, position, length);
++    }
++
++    @Override
++    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
++        return a.setCharSequence(index, sequence, charset);
++    }
++
++    @Override
++    public short readShortLE() {
++        return a.readShortLE();
++    }
++
++    @Override
++    public int readUnsignedShortLE() {
++        return a.readUnsignedShortLE();
++    }
++
++    @Override
++    public int readMediumLE() {
++        return a.readMediumLE();
++    }
++
++    @Override
++    public int readUnsignedMediumLE() {
++        return a.readUnsignedMediumLE();
++    }
++
++    @Override
++    public int readIntLE() {
++        return a.readIntLE();
++    }
++
++    @Override
++    public long readUnsignedIntLE() {
++        return a.readUnsignedIntLE();
++    }
++
++    @Override
++    public long readLongLE() {
++        return a.readLongLE();
++    }
++
++    @Override
++    public float readFloatLE() {
++        return a.readFloatLE();
++    }
++
++    @Override
++    public double readDoubleLE() {
++        return a.readDoubleLE();
++    }
++
++    @Override
++    public ByteBuf readRetainedSlice(int length) {
++        return a.readRetainedSlice(length);
++    }
++
++    @Override
++    public CharSequence readCharSequence(int length, Charset charset) {
++        return a.readCharSequence(length, charset);
++    }
++
++    @Override
++    public int readBytes(FileChannel out, long position, int length) throws IOException {
++        return a.readBytes(out, position, length);
++    }
++
++    @Override
++    public ByteBuf writeShortLE(int value) {
++        return a.writeShortLE(value);
++    }
++
++    @Override
++    public ByteBuf writeMediumLE(int value) {
++        return a.writeMediumLE(value);
++    }
++
++    @Override
++    public ByteBuf writeIntLE(int value) {
++        return a.writeIntLE(value);
++    }
++
++    @Override
++    public ByteBuf writeLongLE(long value) {
++        return a.writeLongLE(value);
++    }
++
++    @Override
++    public ByteBuf writeFloatLE(float value) {
++        return a.writeFloatLE(value);
++    }
++
++    @Override
++    public ByteBuf writeDoubleLE(double value) {
++        return a.writeDoubleLE(value);
++    }
++
++    @Override
++    public int writeBytes(FileChannel in, long position, int length) throws IOException {
++        return a.writeBytes(in, position, length);
++    }
++
++    @Override
++    public int writeCharSequence(CharSequence sequence, Charset charset) {
++        return a.writeCharSequence(sequence, charset);
++    }
++
++    @Override
++    public int forEachByte(ByteProcessor processor) {
++        return a.forEachByte(processor);
++    }
++
++    @Override
++    public int forEachByte(int index, int length, ByteProcessor processor) {
++        return a.forEachByte(index, length, processor);
++    }
++
++    @Override
++    public int forEachByteDesc(ByteProcessor processor) {
++        return a.forEachByteDesc(processor);
++    }
++
++    @Override
++    public int forEachByteDesc(int index, int length, ByteProcessor processor) {
++        return a.forEachByteDesc(index, length, processor);
++    }
++
++    @Override
++    public ByteBuf retainedSlice() {
++        return a.retainedSlice();
++    }
++
++    @Override
++    public ByteBuf retainedSlice(int index, int length) {
++        return a.retainedSlice(index, length);
++    }
++
++    @Override
++    public ByteBuf retainedDuplicate() {
++        return a.retainedDuplicate();
++    }
++
++    @Override
++    public boolean isContiguous() {
++        return a.isContiguous();
++    }
++
++    @Override
++    public ByteBuf touch() {
++        return a.touch();
++    }
++
++    @Override
++    public ByteBuf touch(Object hint) {
++        return a.touch(hint);
++    }
++    // SportPaper end
+ }
+-- 
+2.38.1
+

--- a/patches/server/0212-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
+++ b/patches/server/0212-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
@@ -1,0 +1,33 @@
+From c678dc7693d1801560d10b7cc32c1909081a33d7 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Sun, 31 Oct 2021 09:46:32 -0400
+Subject: [PATCH] Set cap on JDK per-thread native byte buffer cache
+
+See: https://www.evanjones.ca/java-bytebuffer-leak.html
+
+This is potentially a source of lots of native memory usage.
+
+We are clearly seeing native usage upwards to 1-4GB which doesn't make sense.
+
+Region File usage fixed in previous patch should of tecnically only been somewhat
+temporary until GC finally gets it some time later, but between all the various
+plugins doing IO on various threads, this hidden detail of the JDK could be
+keeping long lived large direct buffers in cache.
+
+Set system properly at server startup if not set already to help protect from this.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index d1ce7a86..737904d4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -18,6 +18,7 @@ public class Main {
+ 
+     public static void main(String[] args) {
+         // Todo: Installation script
++        if (System.getProperty("jdk.nio.maxCachedBufferSize") == null) System.setProperty("jdk.nio.maxCachedBufferSize", "262144"); // SportPaper - cap per-thread NIO cache size
+         OptionParser parser = new OptionParser() {
+             {
+                 acceptsAll(asList("?", "help"), "Show the help");
+-- 
+2.38.1
+


### PR DESCRIPTION
The first patch adds support for up to and including Java 11 by updating Netty to the latest upstream version. This patch is sourced from [PandaSpigot](https://github.com/hpfxd/PandaSpigot), so thank you to hpfxd and other contributors to that project.

Previously, ViaVersion, Citizens, and ProtocolLib have had issues with this sort of patch. The newest versions of these plugins which still support 1.8.8 have resolved those issues, and other Paper patch sets which use this patch no longer include patches for those plugins. See discussion in #58.

The second patch is not directly related compatibility wise but seemed relevant nonetheless.

I've used a build of SportPaper with this patch when testing PGM locally for some months now with no issue, but I can't say I'm certain there would be 0 issues encountered in production without trying first.

Closes #58 