### PR TITLE
Upstream and/or backport miscellaneous patches

### DIFF
--- a/patches/server/0218-Add-setting-to-check-line-of-sight.patch
+++ b/patches/server/0218-Add-setting-to-check-line-of-sight.patch
@@ -1,0 +1,36 @@
+From 2ec0a95c46a09efb7a92dd200185ac850a5a6c1d Mon Sep 17 00:00:00 2001
+From: halfmaster1 <ohpointfive@gmail.com>
+Date: Wed, 5 May 2021 02:20:01 -0400
+Subject: [PATCH] Add setting to check line of sight
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 5e903d40..d3c6c3ff 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1464,7 +1464,7 @@ public class PlayerConnection implements PacketListenerPlayIn, IUpdatePlayerList
+ 
+         this.player.resetIdleTimer();
+         if (entity != null) {
+-            boolean flag = this.player.hasLineOfSight(entity);
++            boolean flag = !PaperSpigotConfig.checkLineOfSight || this.player.hasLineOfSight(entity);
+             double d0 = 36.0D;
+ 
+             if (!flag) {
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index 8d58d1f3..ca028d04 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -225,4 +225,9 @@ public class PaperSpigotConfig
+                 knockbackExtraVertical));
+     }
+ 
++    public static boolean checkLineOfSight = true;
++    private static void checkLineOfSight() {
++        checkLineOfSight = getBoolean("settings.check-line-of-sight", checkLineOfSight);
++    }
++
+ }
+-- 
+2.39.2
+

--- a/patches/server/0219-Make-critical-hits-configurable.patch
+++ b/patches/server/0219-Make-critical-hits-configurable.patch
@@ -1,0 +1,36 @@
+From 500389b43f88e74bf0444a4c7f02eec612419f11 Mon Sep 17 00:00:00 2001
+From: halfmaster1 <ohpointfive@gmail.com>
+Date: Tue, 18 May 2021 04:28:46 -0400
+Subject: [PATCH] Make critical hits configurable
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 0e68599d..ef182d42 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -1015,7 +1015,7 @@ public abstract class EntityHuman extends EntityLiving {
+                     boolean flag = !world.paperSpigotConfig.disablePlayerCrits && this.fallDistance > 0.0F && !this.onGround && !this.k_() && !this.V() && !this.hasEffect(MobEffectList.BLINDNESS) && this.vehicle == null && entity instanceof EntityLiving; // PaperSpigot
+ 
+                     if (flag && f > 0.0F) {
+-                        f *= 1.5F;
++                        f *= PaperSpigotConfig.criticalHitMultiplier;
+                     }
+ 
+                     f += f1;
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index ca028d04..8cdcaf3a 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -230,4 +230,9 @@ public class PaperSpigotConfig
+         checkLineOfSight = getBoolean("settings.check-line-of-sight", checkLineOfSight);
+     }
+ 
++    public static float criticalHitMultiplier = 1.5F;
++    private static void criticalHitMultiplier() {
++        criticalHitMultiplier = (float) getDouble("settings.critical-hit-multiplier", (double) criticalHitMultiplier);
++    }
++
+ }
+-- 
+2.39.2
+

--- a/patches/server/0220-Optimize-networking-by-using-IP_TOS.patch
+++ b/patches/server/0220-Optimize-networking-by-using-IP_TOS.patch
@@ -1,0 +1,22 @@
+From 94b14fa428771a46eda1560dc4ea12a75094ca73 Mon Sep 17 00:00:00 2001
+From: Heath Logan Campbell <github@heathlogancampbell.com>
+Date: Fri, 31 Jul 2020 12:43:00 +0200
+Subject: [PATCH] Optimize networking by using IP_TOS
+
+Ported from Titanium, originally from NachoSpigot
+
+diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
+index cc6f993b..052139d4 100644
+--- a/src/main/java/net/minecraft/server/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/ServerConnection.java
+@@ -98,6 +98,7 @@ public class ServerConnection {
+                 protected void initChannel(Channel channel) throws Exception {
+                     try {
+                         channel.config().setOption(ChannelOption.TCP_NODELAY, Boolean.valueOf(true));
++                        channel.config().setOption(ChannelOption.IP_TOS, 0x18); // SportPaper - Optimize networking by using IP_TOS
+                     } catch (ChannelException channelexception) {
+                         ;
+                     }
+-- 
+2.39.2
+

--- a/patches/server/0221-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0221-Add-Unix-domain-socket-support.patch
@@ -1,0 +1,220 @@
+From 6205973d8597aabd4c209c05fe24176c6ee63704 Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Tue, 11 May 2021 17:39:22 -0400
+Subject: [PATCH] Add Unix domain socket support
+
+Backported from Paper upstream
+https://github.com/PaperMC/Paper/pull/5611
+
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index 79a53cc4..a8fa7bbf 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -164,19 +164,39 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+ 
+             this.r = WorldSettings.a(i);
+             DedicatedServer.LOGGER.info("Default game type: " + this.r);
+-            InetAddress inetaddress = null;
+ 
+-            if (this.getServerIp().length() > 0) {
+-                inetaddress = InetAddress.getByName(this.getServerIp());
+-            }
+-
+-            if (this.R() < 0) {
+-                this.setPort(this.propertyManager.getInt("server-port", 25565));
+-            }
++            // SportPaper start - load config earlier to check IP forwarding setting
+             // Spigot start
+             this.a((PlayerList) (new DedicatedPlayerList(this)));
+             // Spigot end
+             SharedConfig.registerCommands();
++            // SportPaper end
++            // Paper start - Unix domain socket support
++            java.net.SocketAddress bindAddress;
++            if (this.getServerIp().startsWith("unix:")) {
++                if (!io.netty.channel.epoll.Epoll.isAvailable()) {
++                    DedicatedServer.LOGGER.error("**** INVALID CONFIGURATION!");
++                    DedicatedServer.LOGGER.error("You are trying to use a Unix domain socket but you're not on a supported OS.");
++                    return false;
++            } else if (!org.spigotmc.SpigotConfig.bungee) {
++                    DedicatedServer.LOGGER.error("**** INVALID CONFIGURATION!");
++                    DedicatedServer.LOGGER.error("Unix domain sockets require IPs to be forwarded from a proxy.");
++                    return false;
++                }
++                bindAddress = new io.netty.channel.unix.DomainSocketAddress(this.getServerIp().substring("unix:".length()));
++            } else {
++                InetAddress inetaddress = null;
++
++                if (this.getServerIp().length() > 0) {
++                    inetaddress = InetAddress.getByName(this.getServerIp());
++                }
++
++                if (this.R() < 0) {
++                    this.setPort(this.propertyManager.getInt("server-port", 25565));
++                }
++                bindAddress = new java.net.InetSocketAddress(inetaddress, this.R());
++            }
++            // Paper end
+ 
+             DedicatedServer.LOGGER.info("Generating keypair");
+             this.a(MinecraftEncryption.b());
+@@ -184,7 +204,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+ 
+         if (!org.spigotmc.SpigotConfig.lateBind) {
+             try {
+-                this.aq().a(inetaddress, this.R());
++                this.aq().bind(bindAddress); // Paper - Unix domain socket support
+             } catch (IOException ioexception) {
+                 DedicatedServer.LOGGER.warn("**** FAILED TO BIND TO PORT!");
+                 DedicatedServer.LOGGER.warn("The exception was: {}", new Object[] { ioexception.toString()});
+@@ -280,7 +300,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+ 
+         if (org.spigotmc.SpigotConfig.lateBind) {
+             try {
+-                this.aq().a(inetaddress, this.R());
++                this.aq().bind(bindAddress); // Paper - Unix domain socket support
+             } catch (IOException ioexception) {
+                 DedicatedServer.LOGGER.warn("**** FAILED TO BIND TO PORT!");
+                 DedicatedServer.LOGGER.warn("The exception was: {}", new Object[] { ioexception.toString()});
+diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
+index 5454f2b5..f4a3c2f5 100644
+--- a/src/main/java/net/minecraft/server/HandshakeListener.java
++++ b/src/main/java/net/minecraft/server/HandshakeListener.java
+@@ -29,34 +29,36 @@ public class HandshakeListener implements PacketHandshakingInListener {
+ 
+             // CraftBukkit start - Connection throttle
+             try {
+-                long currentTime = System.currentTimeMillis();
+-                long connectionThrottle = MinecraftServer.getServer().server.getConnectionThrottle();
+-                InetAddress address = ((java.net.InetSocketAddress) this.b.getSocketAddress()).getAddress();
++                if (!(this.b.channel.localAddress() instanceof io.netty.channel.unix.DomainSocketAddress)) { // Paper - the connection throttle is useless when you have a Unix domain socket
++                    long currentTime = System.currentTimeMillis();
++                    long connectionThrottle = MinecraftServer.getServer().server.getConnectionThrottle();
++                    InetAddress address = ((java.net.InetSocketAddress) this.b.getSocketAddress()).getAddress();
++
++                    synchronized (throttleTracker) {
++                        if (throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - throttleTracker.get(address) < connectionThrottle) {
++                            throttleTracker.put(address, currentTime);
++                            chatcomponenttext = new ChatComponentText("Connection throttled! Please wait before reconnecting.");
++                            this.b.handle(new PacketLoginOutDisconnect(chatcomponenttext));
++                            this.b.close(chatcomponenttext);
++                            return;
++                        }
+ 
+-                synchronized (throttleTracker) {
+-                    if (throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - throttleTracker.get(address) < connectionThrottle) {
+                         throttleTracker.put(address, currentTime);
+-                        chatcomponenttext = new ChatComponentText("Connection throttled! Please wait before reconnecting.");
+-                        this.b.handle(new PacketLoginOutDisconnect(chatcomponenttext));
+-                        this.b.close(chatcomponenttext);
+-                        return;
+-                    }
+-
+-                    throttleTracker.put(address, currentTime);
+-                    throttleCounter++;
+-                    if (throttleCounter > 200) {
+-                        throttleCounter = 0;
+-
+-                        // Cleanup stale entries
+-                        java.util.Iterator iter = throttleTracker.entrySet().iterator();
+-                        while (iter.hasNext()) {
+-                            java.util.Map.Entry<InetAddress, Long> entry = (java.util.Map.Entry) iter.next();
+-                            if (entry.getValue() > connectionThrottle) {
+-                                iter.remove();
++                        throttleCounter++;
++                        if (throttleCounter > 200) {
++                            throttleCounter = 0;
++
++                            // Cleanup stale entries
++                            java.util.Iterator iter = throttleTracker.entrySet().iterator();
++                            while (iter.hasNext()) {
++                                java.util.Map.Entry<InetAddress, Long> entry = (java.util.Map.Entry) iter.next();
++                                if (entry.getValue() > connectionThrottle) {
++                                    iter.remove();
++                                }
+                             }
+                         }
+                     }
+-                }
++                } // Paper - add closing bracket for if check above
+             } catch (Throwable t) {
+                 org.apache.logging.log4j.LogManager.getLogger().debug("Failed to check connection throttle", t);
+             }
+@@ -77,8 +79,11 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                 if (org.spigotmc.SpigotConfig.bungee) {
+                     String[] split = packethandshakinginsetprotocol.hostname.split("\00");
+                     if ( split.length == 3 || split.length == 4 ) {
++                        // Paper start - Unix domain socket support
++                        java.net.SocketAddress socketAddress = b.getSocketAddress();
+                         packethandshakinginsetprotocol.hostname = split[0];
+-                        b.l = new java.net.InetSocketAddress(split[1], ((java.net.InetSocketAddress) b.getSocketAddress()).getPort());
++                        b.l = new java.net.InetSocketAddress(split[1], socketAddress instanceof java.net.InetSocketAddress ? ((java.net.InetSocketAddress) socketAddress).getPort() : 0);
++                        // Paper end
+                         b.spoofedUUID = com.mojang.util.UUIDTypeAdapter.fromString( split[2] );
+                     } else
+                     {
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index 9e35715a..854d1196 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -340,6 +340,11 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet> {
+     // Spigot Start
+     public SocketAddress getRawAddress()
+     {
++        // Paper start - this can be nullable in the case of a Unix domain socket, so if it is, fake something
++        if (this.channel.remoteAddress() == null) {
++            return new java.net.InetSocketAddress(java.net.InetAddress.getLoopbackAddress(), 0);
++        }
++        // Paper end
+         return this.channel.remoteAddress();
+     }
+     // Spigot End
+diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
+index 052139d4..abdfedf6 100644
+--- a/src/main/java/net/minecraft/server/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/ServerConnection.java
+@@ -77,7 +77,13 @@ public class ServerConnection {
+         this.d = true;
+     }
+ 
++    // Paper start - Unix domain socket support
+     public void a(InetAddress inetaddress, int i) throws IOException {
++        bind(new java.net.InetSocketAddress(inetaddress, i));
++    }
++
++    public void bind(java.net.SocketAddress address) throws IOException {
++        // Paper end
+         List list = this.g;
+ 
+         synchronized (this.g) {
+@@ -85,9 +91,15 @@ public class ServerConnection {
+             LazyInitVar lazyinitvar;
+ 
+             if (Epoll.isAvailable() && this.f.ai()) {
+-                oclass = EpollServerSocketChannel.class;
+-                lazyinitvar = ServerConnection.b;
+-                ServerConnection.e.info("Using epoll channel type");
++                // Paper start - Unix domain socket support
++                if (address instanceof io.netty.channel.unix.DomainSocketAddress) {
++                    oclass = io.netty.channel.epoll.EpollServerDomainSocketChannel.class;
++                } else {
++                    oclass = EpollServerSocketChannel.class;
++                }
++                // Paper end
++                    lazyinitvar = ServerConnection.b;
++                    ServerConnection.e.info("Using epoll channel type");
+             } else {
+                 oclass = NioServerSocketChannel.class;
+                 lazyinitvar = ServerConnection.a;
+@@ -110,7 +122,7 @@ public class ServerConnection {
+                     channel.pipeline().addLast("packet_handler", networkmanager);
+                     networkmanager.a((PacketListener) (new HandshakeListener(ServerConnection.this.f, networkmanager)));
+                 }
+-            }).group((EventLoopGroup) lazyinitvar.c()).localAddress(inetaddress, i)).bind().syncUninterruptibly());
++            }).group((EventLoopGroup) lazyinitvar.c()).localAddress(address)).bind().syncUninterruptibly()); // Paper - Unix domain socket support
+         }
+     }
+ 
+-- 
+2.39.2
+

--- a/patches/server/0222-Fix-east-west-cannoning.patch
+++ b/patches/server/0222-Fix-east-west-cannoning.patch
@@ -1,0 +1,66 @@
+From 9e08031e6d1ffab0b44dd8d3d8d24e164dbde8f5 Mon Sep 17 00:00:00 2001
+From: AmbrosL <AmbrosL@users.noreply.github.com>
+Date: Sat, 10 Mar 2018 02:33:28 +0100
+Subject: [PATCH] Fix east/west cannoning
+
+Ported to SportPaper from TacoSpigot and Titanium
+https://github.com/TacoSpigot/TacoSpigot/pull/89
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 0d95a296..2790207d 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -38,6 +38,7 @@ import org.bukkit.plugin.PluginManager;
+ // CraftBukkit end
+ 
+ // PaperSpigot start
++import org.github.paperspigot.PaperSpigotWorldConfig;
+ import org.spigotmc.event.entity.EntityDismountEvent;
+ // PaperSpigot end
+ 
+@@ -555,17 +556,34 @@ public abstract class Entity implements ICommandListener {
+             AxisAlignedBB axisalignedbb2;
+             Iterator iterator1;
+ 
+-            for (iterator1 = list.iterator(); iterator1.hasNext(); d0 = axisalignedbb2.a(this.getBoundingBox(), d0)) {
+-                axisalignedbb2 = (AxisAlignedBB) iterator1.next();
+-            }
++            // SportPaper start - fix east/west cannoning by calculating the z movement before x if the x velocity is greater
++            if (PaperSpigotWorldConfig.fixCannons && Math.abs(d0) > Math.abs(d2)) {
++                for (iterator1 = list.iterator(); iterator1.hasNext(); d2 = axisalignedbb2.c(this.getBoundingBox(), d2)) {
++                    axisalignedbb2 = (AxisAlignedBB) iterator1.next();
++                }
+ 
+-            this.a(this.getBoundingBox().c(d0, 0.0D, 0.0D));
++                this.a(this.getBoundingBox().c(0.0D, 0.0D, d2));
++
++                for (iterator1 = list.iterator(); iterator1.hasNext(); d0 = axisalignedbb2.a(this.getBoundingBox(), d0)) {
++                    axisalignedbb2 = (AxisAlignedBB) iterator1.next();
++                }
++
++                this.a(this.getBoundingBox().c(d0, 0.0D, 0.0D));
++            } else {
++                for (iterator1 = list.iterator(); iterator1.hasNext(); d0 = axisalignedbb2.a(this.getBoundingBox(), d0)) {
++                    axisalignedbb2 = (AxisAlignedBB) iterator1.next();
++                }
++
++                this.a(this.getBoundingBox().c(d0, 0.0D, 0.0D));
++
++                for (iterator1 = list.iterator(); iterator1.hasNext(); d2 = axisalignedbb2.c(this.getBoundingBox(), d2)) {
++                    axisalignedbb2 = (AxisAlignedBB) iterator1.next();
++                }
++
++                this.a(this.getBoundingBox().c(0.0D, 0.0D, d2));
++            } // SportPaper end
+ 
+-            for (iterator1 = list.iterator(); iterator1.hasNext(); d2 = axisalignedbb2.c(this.getBoundingBox(), d2)) {
+-                axisalignedbb2 = (AxisAlignedBB) iterator1.next();
+-            }
+ 
+-            this.a(this.getBoundingBox().c(0.0D, 0.0D, d2));
+             if (this.S > 0.0F && flag1 && (d6 != d0 || d8 != d2)) {
+                 double d10 = d0;
+                 double d11 = d1;
+-- 
+2.39.2
+


### PR DESCRIPTION
This PR contains several patches.

The first two have been deployed on Overcast Community's BOLT and Stratus Network for some time now. These permit hits to be dealt in combat without strict line of sight, and for the damage multipler of critical hits to be modified. I have cleaned up the former patch slightly compared to its deployed states, ensuring vanilla behaviour as default (potentially important for anticheats), but unless I made some error it should function as expected.

The remaining patches come from Paper itself or other Paper or Spigot forks. The simplest of these sets IP_TOS 0x18 for Netty; I'm not very knowledgeable as to what this entails but from what I have read it seems like a desirable network configuration option. Another, backported from modern Paper, adds Unix domain socket support.

The last patch comes from NachoSpigot via Titanium, and resolves long-standing issues with east-west TNT cannons by "calculating the z movement before x if the x velocity is greater". This has been linked to the pre-existing cannon fixes configuration option from Paper as it doesn't necessarily function as expected without it.

Currently marked as draft as I haven't had the chance to test the Unix domain socket support patch.