### PR TITLE
Resolve build issues with Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         java:
           - "8"
+          - "17"
     runs-on: ubuntu-latest
     steps:
       - id: checkout
@@ -44,13 +45,14 @@ jobs:
         name: Upload SportPaper
         uses: actions/upload-artifact@v3
         with:
-          name: SportPaper.jar
+          name: SportPaper-Java-${{ matrix.java }}.jar
           path: SportPaper-Server/target/sportpaper-*.jar
           if-no-files-found: error
       - id: deploy
         if: |
           github.repository_owner == 'Electroid' &&
-          github.ref == 'refs/heads/main'
+          github.ref == 'refs/heads/main' &&
+          matrix.java == '8'
         name: Deploy SportPaper
         run: mvn --batch-mode deploy
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = base/Paper
 	url = https://github.com/PaperMC/Paper.git
 	branch = ver/1.8.8
+[submodule "builddata"]
+	path = builddata
+	url = https://hub.spigotmc.org/stash/scm/spigot/builddata.git

--- a/patches/api/0104-Resolve-build-issues-with-Java-17.patch
+++ b/patches/api/0104-Resolve-build-issues-with-Java-17.patch
@@ -1,0 +1,52 @@
+From 81dd7459c531be2ee75c69944c3102c2acdbd2e0 Mon Sep 17 00:00:00 2001
+From: "BT (calcastor/mame)" <43831917+calcastor@users.noreply.github.com>
+Date: Mon, 6 Feb 2023 23:31:31 -0800
+Subject: [PATCH] Resolve build issues with Java 17
+
+https://github.com/CobbleSword/NachoSpigot/commit/944e02c131b4f4f12a3140778fc9d681f773ae2c
+
+diff --git a/pom.xml b/pom.xml
+index 76533897..ab017e4b 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -28,14 +28,6 @@
+         </repository>
+     </repositories>
+ 
+-    <!-- required until fixed plexus-compiler-eclipse is deployed -->
+-    <pluginRepositories>
+-        <pluginRepository>
+-            <id>spigotmc-public</id>
+-            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+-        </pluginRepository>
+-    </pluginRepositories>
+-
+     <dependencies>
+         <dependency>
+             <groupId>com.google.code.findbugs</groupId>
+@@ -115,22 +107,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-compiler-plugin</artifactId>
+-                <!-- versions after this appear to be broken -->
+                 <version>3.1</version>
+-                <configuration>
+-                    <!-- we use the Eclipse compiler as it doesn't need a JDK -->
+-                    <compilerId>eclipse</compilerId>
+-                    <!-- source and target are ignored if this isn't true -->
+-                    <optimize>true</optimize>
+-                </configuration>
+-                <dependencies>
+-                    <!-- we need our custom version as it fixes some bugs on case sensitive file systems -->
+-                    <dependency>
+-                        <groupId>org.codehaus.plexus</groupId>
+-                        <artifactId>plexus-compiler-eclipse</artifactId>
+-                        <version>2.5.0-spigotmc</version>
+-                    </dependency>
+-                </dependencies>
+             </plugin>
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+-- 
+2.39.1
+

--- a/patches/server/0211-Add-events-for-water-source-creation.patch
+++ b/patches/server/0211-Add-events-for-water-source-creation.patch
@@ -1,4 +1,4 @@
-From 62c738039a2cff268d2f5a9dbf2916741ff4ab1f Mon Sep 17 00:00:00 2001
+From bc723759409412b6e0964f958f8c5d5ba681bb10 Mon Sep 17 00:00:00 2001
 From: OhPointFive <ohpointfive@gmail.com>
 Date: Thu, 7 Jul 2022 00:33:31 -0400
 Subject: [PATCH] Add events for water source creation
@@ -80,4 +80,5 @@ index be8bb5be..cc4d7319 100644
                  world.setAir(blockposition);
              } else {
 -- 
-2.29.2
+2.39.1
+

--- a/patches/server/0212-Apply-explosion-knockback-to-projectiles.patch
+++ b/patches/server/0212-Apply-explosion-knockback-to-projectiles.patch
@@ -1,4 +1,4 @@
-From 6dd05da521c5e6c6bf38ad396cc6352265ff5eef Mon Sep 17 00:00:00 2001
+From 6d14e77948d1ea5f80ca8d55030901b1351ab31a Mon Sep 17 00:00:00 2001
 From: woofdoggo <woofwoofdoggo@protonmail.com>
 Date: Wed, 11 May 2022 16:49:54 -0400
 Subject: [PATCH] Apply explosion knockback to projectiles
@@ -23,4 +23,5 @@ index 0d6ccbf7..e90b1c23 100644
                          double d14 = entity instanceof EntityHuman && world.paperSpigotConfig.disableExplosionKnockback ? 0 : EnchantmentProtection.a(entity, d13); // PaperSpigot
  
 -- 
-2.36.1
+2.39.1
+

--- a/patches/server/0213-Patch-Book-Exploits.patch
+++ b/patches/server/0213-Patch-Book-Exploits.patch
@@ -1,11 +1,11 @@
-From 3a297b7763c4e609f44e9fbc48b5c8090b1030a7 Mon Sep 17 00:00:00 2001
+From 720e469e8fb7cfeb3710e72294f8ff32edd2ddcc Mon Sep 17 00:00:00 2001
 From: linsaftw <linsaftw@users.noreply.github.com>
 Date: Sun, 25 Apr 2021 11:53:18 -0300
 Subject: [PATCH] Patch Book Exploits
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index 0b5ada01..91d61016 100644
+index 0b5ada01..4175501d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -33,8 +33,10 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
@@ -148,4 +148,5 @@ index 0b5ada01..91d61016 100644
  
      private boolean isValidPage(int page) {
 -- 
-2.31.1
+2.39.1
+

--- a/patches/server/0214-Update-to-Netty-4.1.x.patch
+++ b/patches/server/0214-Update-to-Netty-4.1.x.patch
@@ -1,11 +1,11 @@
-From 42f916afdb36bd909528c561005c98395a503a58 Mon Sep 17 00:00:00 2001
+From 0325b9e8caeded0950255f34ede21315daf7217c Mon Sep 17 00:00:00 2001
 From: hpfxd <me@hpfxd.com>
 Date: Wed, 27 Oct 2021 06:29:44 -0400
 Subject: [PATCH] Update to Netty 4.1.x
 
 
 diff --git a/pom.xml b/pom.xml
-index 2dee42e5..e6ea4704 100644
+index 2dee42e5..e6bdad05 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -27,6 +27,11 @@
@@ -316,4 +316,5 @@ index e2eb3054..9a075fef 100644
 +    // SportPaper end
  }
 -- 
-2.38.1
+2.39.1
+

--- a/patches/server/0215-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
+++ b/patches/server/0215-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
@@ -1,4 +1,4 @@
-From c678dc7693d1801560d10b7cc32c1909081a33d7 Mon Sep 17 00:00:00 2001
+From 8aee7038640e23b9c81a6f2668fc391dd4a82849 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 31 Oct 2021 09:46:32 -0400
 Subject: [PATCH] Set cap on JDK per-thread native byte buffer cache
@@ -29,4 +29,5 @@ index d1ce7a86..737904d4 100644
              {
                  acceptsAll(asList("?", "help"), "Show the help");
 -- 
-2.38.1
+2.39.1
+

--- a/patches/server/0217-Resolve-build-issues-with-Java-17.patch
+++ b/patches/server/0217-Resolve-build-issues-with-Java-17.patch
@@ -1,0 +1,50 @@
+From 035add76003f231d327e10fd7718411140e61b18 Mon Sep 17 00:00:00 2001
+From: "BT (calcastor/mame)" <43831917+calcastor@users.noreply.github.com>
+Date: Mon, 6 Feb 2023 23:30:48 -0800
+Subject: [PATCH] Resolve build issues with Java 17
+
+https://github.com/CobbleSword/NachoSpigot/commit/944e02c131b4f4f12a3140778fc9d681f773ae2c
+
+diff --git a/pom.xml b/pom.xml
+index e6bdad05..6959c62a 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -105,12 +105,7 @@
+         </dependency>
+     </dependencies>
+ 
+-    <!-- required until fixed plexus-compiler-eclipse is deployed -->
+     <pluginRepositories>
+-        <pluginRepository>
+-            <id>spigotmc-public</id>
+-            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+-        </pluginRepository>
+         <!-- PaperSpigot - Repo for gitdescribe -->
+         <pluginRepository>
+             <id>destroystokyo</id>
+@@ -281,22 +276,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-compiler-plugin</artifactId>
+-                <!-- versions after this appear to be broken -->
+                 <version>3.1</version>
+-                <configuration>
+-                    <!-- we use the Eclipse compiler as it doesn't need a JDK -->
+-                    <compilerId>eclipse</compilerId>
+-                    <!-- source and target are ignored if this isn't true -->
+-                    <optimize>true</optimize>
+-                </configuration>
+-                <dependencies>
+-                    <!-- we need our custom version as it fixes some bugs on case sensitive file systems -->
+-                    <dependency>
+-                        <groupId>org.codehaus.plexus</groupId>
+-                        <artifactId>plexus-compiler-eclipse</artifactId>
+-                        <version>2.5.0-spigotmc</version>
+-                    </dependency>
+-                </dependencies>
+             </plugin>
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+-- 
+2.39.1
+

--- a/scripts/upstream.sh
+++ b/scripts/upstream.sh
@@ -30,7 +30,13 @@ cp -f scripts/basenewApplyPatches.sh base/Paper/newApplyPatches.sh
 
 cd "$basedir/base/Paper/"
 
-git submodule update --init && ./remap.sh && ./decompile.sh && ./init.sh && ./newApplyPatches.sh
+git submodule update --init
+
+# To compile with Java 17, we need newer copies of SpecialSource.jar and SpecialSource-2.jar
+cp -f "$basedir/builddata/bin/SpecialSource.jar" BuildData/bin/SpecialSource.jar
+cp -f "$basedir/builddata/bin/SpecialSource-2.jar" BuildData/bin/SpecialSource-2.jar
+
+./remap.sh && ./decompile.sh && ./init.sh && ./newApplyPatches.sh
 
 cd "PaperSpigot-Server"
 mcVer=$(mvn -o org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=minecraft_version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }')


### PR DESCRIPTION
This PR fixes issues with building SportPaper using Java 17, and switches the workflow over accordingly.

In order to build with Java 17, we need newer copies of SpecialSource and SpecialSource-2 than those provided in the Paper 1.8.8 branch's BuildData submodule from Spigot. As such, I have added a submodule in the repository root which points to the latest BuildData commit from Spigot. We copy the jars for SpecialSource and SpecialSource-2 from this submodule and overwrite them in the Paper submodule, once all of the Paper submodules are initialised.

Upstream BuildData also contains a newer version of Fernflower, however the format of the decompiled code differs from the version of Fernflower currently used, and therefore all patches would need reformatting. Since the version of Fernflower that is currently used does not seem to cause any issue, there doesn't seem to be any benefit to updating it at the moment.

The biggest caveat here is that the newer versions of SpecialSource and SpecialSource-2 likely make Java 17 mandatory for decompilation. Perhaps it's worth testing the versions provided for 1.16.x, the last version to use Java 8, but I'll only look into this if it's desired.