### PR TITLE
Fix setup error caused by upstream script on Windows

### DIFF
--- a/scripts/upstream.sh
+++ b/scripts/upstream.sh
@@ -49,7 +49,11 @@ minecraftversion=$(cat "$basedir/base/Paper/BuildData/info.json" | grep minecraf
 cd base/Paper/
 
 version=$(echo -e "Paper: $paperVer\nmc-dev:$importedmcdev")
-tag="${minecraftversion}-${mcVer}-$(echo -e $version | shasum | awk '{print $1}')"
+if [[ "$OSTYPE" =~ ^msys ]]; then
+    tag="${minecraftversion}-${mcVer}-$(echo -e $version | sha1sum | awk '{print $1}')"
+else
+    tag="${minecraftversion}-${mcVer}-$(echo -e $version | shasum | awk '{print $1}')"
+fi
 
 function tag {
 (


### PR DESCRIPTION
This pull request fixes an issue where the `upstream.sh script` fails script fails to generate a tag on Windows using Git Bash. The fix adds a conditional check to determine the operating system type and dynamically selects the appropriate shasum command for generating the tag.