### PR TITLE
Fix issues with non-interacting players

### DIFF
--- a/patches/server/0001-Fix-Decompilation-errors.patch
+++ b/patches/server/0001-Fix-Decompilation-errors.patch
@@ -1,9 +1,24 @@
-From 97eb4c50bb22267d87f9e136ce1e6e85f1c27032 Mon Sep 17 00:00:00 2001
+From e49d3924fb3cdc1fff4749c20ce5ae4b7ba20506 Mon Sep 17 00:00:00 2001
 From: cswhite2000 <18whitechristop@gmail.com>
 Date: Mon, 6 Aug 2018 16:39:57 -0700
 Subject: [PATCH] Fix Decompilation errors
 
 
+diff --git a/src/main/java/net/minecraft/server/IEntitySelector.java b/src/main/java/net/minecraft/server/IEntitySelector.java
+index 81c45a95a..c27709e1f 100644
+--- a/src/main/java/net/minecraft/server/IEntitySelector.java
++++ b/src/main/java/net/minecraft/server/IEntitySelector.java
+@@ -61,8 +61,8 @@ public final class IEntitySelector {
+             }
+         }
+ 
+-        public boolean apply(Object object) {
+-            return this.a((Entity) object);
++        public boolean apply(Entity entity) {
++            return this.a(entity);
+         }
+     }
+ }
 diff --git a/src/main/java/net/minecraft/server/PacketPlayInUseEntity.java b/src/main/java/net/minecraft/server/PacketPlayInUseEntity.java
 index f55bedaff..a8fc3361a 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayInUseEntity.java
@@ -61,5 +76,5 @@ index 90606f50b..4b8eb3eed 100644
 -    }
  }
 -- 
-2.18.0
+2.28.0.windows.1
 

--- a/patches/server/0223-Fix-issues-with-non-interacting-players.patch
+++ b/patches/server/0223-Fix-issues-with-non-interacting-players.patch
@@ -1,0 +1,34 @@
+From 9d852f70d935108fa73a21a51904fe159ebc1f93 Mon Sep 17 00:00:00 2001
+From: Pugzy <pugzy@mail.com>
+Date: Fri, 29 Sep 2023 17:35:55 +0100
+Subject: [PATCH] Fix issues with non-interacting players
+
+
+diff --git a/src/main/java/net/minecraft/server/IEntitySelector.java b/src/main/java/net/minecraft/server/IEntitySelector.java
+index c27709e1f..fb5bb04be 100644
+--- a/src/main/java/net/minecraft/server/IEntitySelector.java
++++ b/src/main/java/net/minecraft/server/IEntitySelector.java
+@@ -50,7 +50,7 @@ public final class IEntitySelector {
+         }
+ 
+         public boolean a(Entity entity) {
+-            if (!entity.isAlive()) {
++            if (!entity.ad()) { // SportPaper - exempt non-interacting players
+                 return false;
+             } else if (!(entity instanceof EntityLiving)) {
+                 return false;
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 3e5332f9e..394b35b14 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -1289,6 +1289,7 @@ public abstract class World implements IBlockAccess {
+ 
+         for (int j2 = 0; j2 < list.size(); ++j2) {
+             if (entity.passenger != list && entity.vehicle != list) {
++                if (!((Entity) list.get(j2)).ad()) continue; // SportPaper - Fix boat placing collision
+                 AxisAlignedBB axisalignedbb1 = ((Entity) list.get(j2)).S();
+ 
+                 if (axisalignedbb1 != null && axisalignedbb1.b(axisalignedbb)) {
+-- 
+2.28.0.windows.1
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -62,6 +62,7 @@ import MerchantRecipeList
 import DamageSource
 import ServerNBTManager
 import IChunkLoader
+import IEntitySelector
 
 cd "$basedir/base/Paper/PaperSpigot-Server/"
 rm -rf nms-patches applyPatches.sh makePatches.sh >/dev/null 2>&1


### PR DESCRIPTION
Not a clue what I'm doing with these patches to be honest but it works (I think).

Fixes two issues with "observers" i.e. players who are non-interacting using the `ad()` check.
For `EntityLiving` players this does a `collidesWithEntities` check and a parent `ad` which checks for `!this.dead`.

**Prevents non-interacting players from stopping boat placement**
- Entities with collision turned off will no longer prevent players from placing boats that would collide with them.
- This implementation also extends to other entities which do not have a hitbox.
  - This means that entities such as items and arrows also no longer block arrows (default in newer versions of MC) .

**Prevents non-interacting players from being given armor from a dispenser**
- Players in an "Observers" mode could stand in front of a dispenser and be given the items.
- Changes a method which uses `!alive` to the `ad()` which includes both a collision and alive check.

