### PR TITLE
Support for Java 17+

### DIFF
--- a/patches/api/0105-Add-internal-setMaxStackSize-method-for-materials.patch
+++ b/patches/api/0105-Add-internal-setMaxStackSize-method-for-materials.patch
@@ -1,0 +1,45 @@
+From 889edef0facc5a2ed1c6a808663f807acdb3eeef Mon Sep 17 00:00:00 2001
+From: hpfxd <me@hpfxd.com>
+Date: Wed, 27 Oct 2021 20:45:30 -0400
+Subject: [PATCH] Add internal setMaxStackSize method for materials
+
+This is to be used by internal systems that need to set a Material's maximum stack size dynamically, such as stackable buckets in Paper's config.
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index 0fb26055..f1ce4017 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -461,7 +461,7 @@ public enum Material {
+     private final Constructor<? extends MaterialData> ctor;
+     private static Material[] byId = new Material[383];
+     private final static Map<String, Material> BY_NAME = Maps.newHashMap();
+-    private final int maxStack;
++    private int maxStack; // SportPaper - Make non-final
+     private final short durability;
+ 
+     private Material(final int id) {
+@@ -518,6 +518,21 @@ public enum Material {
+         return maxStack;
+     }
+ 
++    // SportPaper start - Add setMaxStackSize()
++    /**
++     * Sets the maximum amount of this material that can be held in a stack.
++     * <p>
++     * <b>This method is for internal use only. Use at your own risk.</b>
++     *
++     * @param maxStack The new maximum stack size for this material.
++     * @deprecated For internal use only.
++     */
++    @Deprecated
++    public void setMaxStackSize(int maxStack) {
++        this.maxStack = maxStack;
++    }
++    // SportPaper end
++
+     /**
+      * Gets the maximum durability of this material
+      *
+-- 
+2.43.0
+

--- a/patches/server/0223-Remove-hacky-stackable-buckets-code.patch
+++ b/patches/server/0223-Remove-hacky-stackable-buckets-code.patch
@@ -1,0 +1,69 @@
+From 3d38a1e462bfcc4a009ace1a8d349f719f9dddce Mon Sep 17 00:00:00 2001
+From: hpfxd <me@hpfxd.com>
+Date: Wed, 27 Oct 2021 20:46:41 -0400
+Subject: [PATCH] Remove hacky stackable buckets code
+
+The old code for stackable buckets involved using reflection to set a final field in the Material class, and completely broke on Java 12+.
+
+The new system uses a method to set the Material's maximum stack size dynamically, without reflection.
+
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index 8cdcaf3a..065dcdf6 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -162,38 +162,23 @@ public class PaperSpigotConfig
+         stackableWaterBuckets = getBoolean( "stackable-buckets.water", false );
+         stackableMilkBuckets = getBoolean( "stackable-buckets.milk", false );
+ 
+-        Field maxStack;
+-
+-        try {
+-            maxStack = Material.class.getDeclaredField("maxStack");
+-            maxStack.setAccessible(true);
+-
+-            Field modifiers = Field.class.getDeclaredField("modifiers");
+-            modifiers.setAccessible(true);
+-            modifiers.setInt(maxStack, maxStack.getModifiers() & ~Modifier.FINAL);
+-        } catch (Exception e) {
+-            e.printStackTrace();
+-            return;
++        // SportPaper start - Remove hacky stackable buckets code that used reflection
++        int size = Material.BUCKET.getMaxStackSize();
++        if (stackableLavaBuckets) {
++            Material.LAVA_BUCKET.setMaxStackSize(size);
++            Items.LAVA_BUCKET.c(size);
+         }
+ 
+-        try {
+-            if (stackableLavaBuckets) {
+-                maxStack.set(Material.LAVA_BUCKET, Material.BUCKET.getMaxStackSize());
+-                Items.LAVA_BUCKET.c(Material.BUCKET.getMaxStackSize());
+-            }
+-
+-            if (stackableWaterBuckets) {
+-                maxStack.set(Material.WATER_BUCKET, Material.BUCKET.getMaxStackSize());
+-                Items.WATER_BUCKET.c(Material.BUCKET.getMaxStackSize());
+-            }
+-
+-            if (stackableMilkBuckets) {
+-                maxStack.set(Material.MILK_BUCKET, Material.BUCKET.getMaxStackSize());
+-                Items.MILK_BUCKET.c(Material.BUCKET.getMaxStackSize());
+-            }
+-        } catch (Exception e) {
+-            e.printStackTrace();
++        if (stackableWaterBuckets) {
++            Material.WATER_BUCKET.setMaxStackSize(size);
++            Items.WATER_BUCKET.c(size);
+         }
++
++        if (stackableMilkBuckets) {
++            Material.MILK_BUCKET.setMaxStackSize(size);
++            Items.MILK_BUCKET.c(size);
++        }
++        // SportPaper end
+     }
+ 
+     public static boolean warnForExcessiveVelocity;
+-- 
+2.43.0
+

--- a/patches/server/0224-Make-dimension-field-non-final.patch
+++ b/patches/server/0224-Make-dimension-field-non-final.patch
@@ -1,0 +1,22 @@
+From d6d18e96f0707b8036baa9a4b6fa6d7518bcd116 Mon Sep 17 00:00:00 2001
+From: "BT (calcastor/mame)" <43831917+calcastor@users.noreply.github.com>
+Date: Sun, 31 Dec 2023 22:03:05 -0800
+Subject: [PATCH] Make dimension field non-final
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 9a2508c8..e536ae29 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -53,7 +53,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+     private List<NextTickListEntry> V = Lists.newArrayList();
+ 
+     // CraftBukkit start
+-    public final int dimension;
++    public int dimension; // SportPaper - make non-final
+ 
+     // Add env and gen to constructor
+     public WorldServer(MinecraftServer minecraftserver, IDataManager idatamanager, WorldData worlddata, int i, MethodProfiler methodprofiler, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
+-- 
+2.43.0
+


### PR DESCRIPTION
The patches in this PR allow for us to run SportPaper (with a patched PGM) on Java 17 and 21. The first commit comes from PandaSpigot and removes use of reflection for a stackable buckets patch added in Paper 1.8.8, while the second commit makes the `dimension` field in `WorldServer` non-final, which is relevant to running PGM on SportPaper with Java 17+.