### PR TITLE
Update v3 GH actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: setup-java
         name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -43,7 +43,7 @@ jobs:
         run: bash sportpaper build
       - id: upload
         name: Upload SportPaper
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SportPaper-Java-${{ matrix.java }}.jar
           path: SportPaper-Server/target/sportpaper-*.jar


### PR DESCRIPTION
Obviously inspired by PGMDev/PGM#1316. I regularly get my copies of SportPaper from the actions tab (and most likely many others too), so I think this is important to keep everything up to date. 

It has been tested on my fork and builds without any issue and removes the Node 16 deprecation warnings.