### PR TITLE
Fix NPE related to BlockDispenseEntityEvent

### DIFF
--- a/patches/server/0226-Readd-NPE-prevention-for-BlockDispenseEntityEvent.patch
+++ b/patches/server/0226-Readd-NPE-prevention-for-BlockDispenseEntityEvent.patch
@@ -1,0 +1,26 @@
+From e0c046f68018df323312eecb0a711587eb0bb029 Mon Sep 17 00:00:00 2001
+From: Christopher White <18whitechristop@gmail.com>
+Date: Sat, 20 Jul 2024 11:28:20 -0700
+Subject: [PATCH] Readd NPE prevention for BlockDispenseEntityEvent
+
+Signed-off-by: Christopher White <18whitechristop@gmail.com>
+
+diff --git a/src/main/java/net/minecraft/server/DispenserRegistry.java b/src/main/java/net/minecraft/server/DispenserRegistry.java
+index 9577483d..5c5ceed7 100644
+--- a/src/main/java/net/minecraft/server/DispenserRegistry.java
++++ b/src/main/java/net/minecraft/server/DispenserRegistry.java
+@@ -89,6 +89,11 @@ public class DispenserRegistry {
+                 CraftItemStack craftItem = CraftItemStack.asCraftMirror(itemstack1);
+ 
+                 Entity entity = ItemMonsterEgg.spawnCreature(isourceblock.getWorld(), itemstack.getData(), d0, d1, d2, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DISPENSE_EGG);
++                if (entity == null) {
++                    // This happens if the spawn event is cancelled
++                    itemstack.count++;
++                    return itemstack;
++                }
+ 
+                 BlockDispenseEntityEvent event = new BlockDispenseEntityEvent(block, craftItem.clone(), new org.bukkit.util.Vector(d0, d1, d2), entity.getBukkitEntity());
+                 if (!BlockDispenser.eventFired) {
+-- 
+2.45.2
+


### PR DESCRIPTION
NPE:
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.server.v1_8_R3.Entity.getBukkitEntity()" because "entity" is null
    at net.minecraft.server.v1_8_R3.DispenserRegistry$6.b(DispenserRegistry.java:93)
    at net.minecraft.server.v1_8_R3.DispenseBehaviorItem.a(DispenseBehaviorItem.java:13)
    at net.minecraft.server.v1_8_R3.BlockDispenser.dispense(BlockDispenser.java:86)
    at net.minecraft.server.v1_8_R3.BlockDispenser.b(BlockDispenser.java:115)
    at net.minecraft.server.v1_8_R3.WorldServer.a(WorldServer.java:683)
    at net.minecraft.server.v1_8_R3.WorldServer.doTick(WorldServer.java:247)
    at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:941)
    at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:385)
    at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:827)
    at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:728)
    at java.base/java.lang.Thread.run(Thread.java:1583)
```